### PR TITLE
Allow Codex sandbox writes to Git worktree metadata

### DIFF
--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -479,10 +479,10 @@ defmodule SymphonyElixir.Config.Schema do
 
   defp normalize_secret_value(_value), do: nil
 
-  defp default_turn_sandbox_policy(workspace) do
+  defp default_turn_sandbox_policy(writable_roots) when is_list(writable_roots) do
     %{
       "type" => "workspaceWrite",
-      "writableRoots" => [workspace],
+      "writableRoots" => writable_roots,
       "readOnlyAccess" => %{"type" => "fullAccess"},
       "networkAccess" => false,
       "excludeTmpdirEnvVar" => false,
@@ -490,19 +490,70 @@ defmodule SymphonyElixir.Config.Schema do
     }
   end
 
+  defp default_turn_sandbox_policy(workspace), do: default_turn_sandbox_policy([workspace])
+
   defp default_runtime_turn_sandbox_policy(workspace_root, opts) when is_binary(workspace_root) do
     if Keyword.get(opts, :remote, false) do
       {:ok, default_turn_sandbox_policy(workspace_root)}
     else
       with expanded_workspace_root <- expand_local_workspace_root(workspace_root),
            {:ok, canonical_workspace_root} <- PathSafety.canonicalize(expanded_workspace_root) do
-        {:ok, default_turn_sandbox_policy(canonical_workspace_root)}
+        writable_roots =
+          canonical_workspace_root
+          |> git_worktree_writable_roots()
+          |> then(&[canonical_workspace_root | &1])
+          |> Enum.uniq()
+          |> prune_nested_roots()
+
+        {:ok, default_turn_sandbox_policy(writable_roots)}
       end
     end
   end
 
   defp default_runtime_turn_sandbox_policy(workspace_root, _opts) do
     {:error, {:unsafe_turn_sandbox_policy, {:invalid_workspace_root, workspace_root}}}
+  end
+
+  defp git_worktree_writable_roots(workspace_root) do
+    ["--git-common-dir", "--git-dir"]
+    |> Enum.flat_map(&git_metadata_root(workspace_root, &1))
+    |> Enum.reject(&path_inside?(&1, workspace_root))
+    |> Enum.uniq()
+  end
+
+  defp git_metadata_root(workspace_root, git_rev_parse_arg) do
+    case System.cmd("git", ["-C", workspace_root, "rev-parse", "--path-format=absolute", git_rev_parse_arg], stderr_to_stdout: true) do
+      {path, 0} ->
+        path
+        |> String.trim()
+        |> canonical_git_metadata_root()
+
+      _ ->
+        []
+    end
+  end
+
+  defp canonical_git_metadata_root(""), do: []
+
+  defp canonical_git_metadata_root(path) do
+    case PathSafety.canonicalize(path) do
+      {:ok, canonical_path} -> [canonical_path]
+      {:error, _reason} -> []
+    end
+  end
+
+  defp path_inside?(path, parent) when is_binary(path) and is_binary(parent) do
+    path == parent or String.starts_with?(path, parent <> "/")
+  end
+
+  defp path_inside?(_path, _parent), do: false
+
+  defp prune_nested_roots(roots) when is_list(roots) do
+    roots
+    |> Enum.sort_by(&String.length/1)
+    |> Enum.reduce([], fn root, acc ->
+      if Enum.any?(acc, &path_inside?(root, &1)), do: acc, else: acc ++ [root]
+    end)
   end
 
   defp default_workspace_root(workspace, _fallback) when is_binary(workspace) and workspace != "",

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -1226,6 +1226,52 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     end
   end
 
+  test "runtime sandbox policy includes git metadata root for source-backed worktrees" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-worktree-sandbox-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      source_repo = Path.join(test_root, "source")
+      workspace_root = Path.join(test_root, "workspaces")
+      issue_workspace = Path.join(workspace_root, "MT-102")
+
+      File.mkdir_p!(source_repo)
+      File.mkdir_p!(workspace_root)
+      File.write!(Path.join(source_repo, "README.md"), "# test\n")
+
+      System.cmd("git", ["-C", source_repo, "init", "-b", "main"])
+      System.cmd("git", ["-C", source_repo, "config", "user.name", "Test User"])
+      System.cmd("git", ["-C", source_repo, "config", "user.email", "test@example.com"])
+      System.cmd("git", ["-C", source_repo, "add", "README.md"])
+      System.cmd("git", ["-C", source_repo, "commit", "-m", "initial"])
+      System.cmd("git", ["-C", source_repo, "worktree", "add", "-b", "symphony/MT-102", issue_workspace, "HEAD"])
+
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+      settings = Config.settings!()
+
+      assert {:ok, canonical_issue_workspace} =
+               SymphonyElixir.PathSafety.canonicalize(issue_workspace)
+
+      assert {:ok, canonical_git_common_dir} =
+               SymphonyElixir.PathSafety.canonicalize(Path.join(source_repo, ".git"))
+
+      assert {:ok, policy} = Schema.resolve_runtime_turn_sandbox_policy(settings, issue_workspace)
+
+      assert policy["type"] == "workspaceWrite"
+      assert canonical_issue_workspace in policy["writableRoots"]
+      assert canonical_git_common_dir in policy["writableRoots"]
+
+      refute Enum.any?(policy["writableRoots"], fn root ->
+               String.ends_with?(root, ".git/worktrees/MT-102")
+             end)
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
   test "workflow prompt is used when building base prompt" do
     workflow_prompt = "Workflow prompt body used as codex instruction."
 


### PR DESCRIPTION
## Summary

Closes #1.

This updates the default local Codex `workspaceWrite` sandbox policy so Symphony can commit from source-backed Git worktrees. The issue workspace remains writable, and Symphony now adds the canonical Git metadata root reported by Git when that metadata lives outside the workspace.

## Implementation

- Allows `default_turn_sandbox_policy/1` to accept a list of writable roots.
- Resolves the issue workspace root with existing `PathSafety` canonicalization.
- Uses `git rev-parse --path-format=absolute --git-common-dir` and `--git-dir` from the actual workspace to discover Git metadata roots.
- Keeps only metadata roots outside the workspace, deduplicates them, and prunes nested roots when a parent root is already writable.
- Leaves remote workers and explicit sandbox policies unchanged.

## Why config alone was insufficient

Raw Symphony only had static sandbox configuration. The correct `.git` metadata path is worktree-specific and should be discovered after workspace creation. A static workflow file could either miss the metadata root or over-grant access to the source repository.

## Tests

```text
mix test test/symphony_elixir/workspace_and_config_test.exs
43 tests, 0 failures
```
