### PR TITLE
Block issues when agents hit missing capabilities

### DIFF
--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -422,6 +422,18 @@ defmodule SymphonyElixir.Codex.AppServer do
       {:error, _reason} ->
         log_non_json_stream_line(payload_string, "turn stream")
 
+        if skill_load_error?(payload_string) do
+          emit_message(
+            on_message,
+            :skill_load_failed,
+            %{
+              payload: payload_string,
+              raw: payload_string
+            },
+            metadata_from_message(port, %{raw: payload_string})
+          )
+        end
+
         if protocol_message_candidate?(payload_string) do
           emit_message(
             on_message,
@@ -575,7 +587,18 @@ defmodule SymphonyElixir.Codex.AppServer do
         _ -> :tool_call_failed
       end
 
-    emit_message(on_message, event, %{payload: payload, raw: payload_string}, metadata)
+    emit_message(
+      on_message,
+      event,
+      %{
+        payload: payload,
+        raw: payload_string,
+        tool_name: tool_name,
+        arguments: arguments,
+        result: result
+      },
+      metadata
+    )
 
     :approved
   end
@@ -984,6 +1007,12 @@ defmodule SymphonyElixir.Codex.AppServer do
     |> to_string()
     |> String.trim_leading()
     |> String.starts_with?("{")
+  end
+
+  defp skill_load_error?(data) do
+    data
+    |> to_string()
+    |> String.contains?("failed to load skill")
   end
 
   defp issue_context(%{id: issue_id, identifier: identifier}) do

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -15,6 +15,7 @@ defmodule SymphonyElixir.Orchestrator do
   @credit_retry_default_delay_ms 3_600_000
   @credit_retry_min_delay_ms 60_000
   @credit_retry_safety_margin_ms 5_000
+  @blocked_state_name "Blocked"
   # Slightly above the dashboard render interval so "checking now…" can render.
   @poll_transition_render_delay_ms 20
   @empty_codex_totals %{
@@ -211,8 +212,19 @@ defmodule SymphonyElixir.Orchestrator do
           |> apply_codex_token_delta(token_delta)
           |> apply_codex_rate_limits(update)
 
+        state = %{state | running: Map.put(running, issue_id, updated_running_entry)}
+
+        state =
+          case capability_gap_from_update(update) do
+            nil ->
+              state
+
+            capability_gap ->
+              block_issue_for_capability_gap(state, issue_id, updated_running_entry, capability_gap)
+          end
+
         notify_dashboard()
-        {:noreply, %{state | running: Map.put(running, issue_id, updated_running_entry)}}
+        {:noreply, state}
     end
   end
 
@@ -458,6 +470,40 @@ defmodule SymphonyElixir.Orchestrator do
       _ ->
         release_issue_claim(state, issue_id)
     end
+  end
+
+  defp block_issue_for_capability_gap(%State{} = state, issue_id, running_entry, {kind, details}) do
+    identifier = Map.get(running_entry, :identifier, issue_id)
+    body = capability_gap_comment(kind, details)
+
+    case Tracker.create_comment(issue_id, body) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to comment capability gap for issue_id=#{issue_id} issue_identifier=#{identifier}: #{inspect(reason)}")
+    end
+
+    case Tracker.update_issue_state(issue_id, @blocked_state_name) do
+      :ok ->
+        Logger.warning("Blocked issue after agent capability gap: issue_id=#{issue_id} issue_identifier=#{identifier} missing=#{kind}")
+
+      {:error, reason} ->
+        Logger.warning("Failed to move capability gap issue to #{@blocked_state_name}: issue_id=#{issue_id} issue_identifier=#{identifier} reason=#{inspect(reason)}")
+    end
+
+    terminate_running_issue(state, issue_id, false)
+  end
+
+  defp capability_gap_comment(kind, details) do
+    """
+    Symphony blocked this issue because the agent is missing a required capability.
+
+    Missing capability: #{kind}
+    Details: #{details}
+
+    The run was stopped to avoid token-consuming workarounds. Fix the missing tool, skill, or permission, then move the issue back to an active pickup state.
+    """
   end
 
   defp reconcile_stalled_running_issues(%State{} = state) do
@@ -1441,6 +1487,66 @@ defmodule SymphonyElixir.Orchestrator do
       timestamp: update[:timestamp]
     }
   end
+
+  defp capability_gap_from_update(%{event: :skill_load_failed} = update) do
+    {:skill, update_text(update)}
+  end
+
+  defp capability_gap_from_update(%{event: :approval_required} = update) do
+    {:permission, "Codex requested approval during an unattended run: #{update_text(update)}"}
+  end
+
+  defp capability_gap_from_update(%{event: :turn_input_required} = update) do
+    {:permission, "Codex required interactive input during an unattended run: #{update_text(update)}"}
+  end
+
+  defp capability_gap_from_update(%{event: :unsupported_tool_call} = update) do
+    tool_name = update[:tool_name] || "<unknown>"
+    {:tool, "Unsupported tool requested: #{tool_name}. #{update_text(update)}"}
+  end
+
+  defp capability_gap_from_update(%{event: :tool_call_failed} = update) do
+    if capability_gap_text?(update_text(update)) do
+      tool_name = update[:tool_name] || "<unknown>"
+      {:tool, "Tool call failed because a capability appears unavailable: #{tool_name}. #{update_text(update)}"}
+    end
+  end
+
+  defp capability_gap_from_update(_update), do: nil
+
+  defp capability_gap_text?(text) when is_binary(text) do
+    String.match?(
+      String.downcase(text),
+      ~r/(unsupported dynamic tool|approval required|not authorized|unauthori[sz]ed|forbidden|permission denied|operation not permitted|access denied|missing (tool|skill|permission|credential|api key|token)|api key.*missing|token.*missing|authentication required)/
+    )
+  end
+
+  defp capability_gap_text?(_text), do: false
+
+  defp update_text(update) when is_map(update) do
+    update
+    |> capability_gap_parts()
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(" ")
+    |> String.slice(0, 2_000)
+  end
+
+  defp capability_gap_parts(update) do
+    [
+      update[:raw],
+      update[:payload],
+      update[:details],
+      update[:result],
+      update[:message]
+    ]
+    |> Enum.map(&capability_gap_part/1)
+  end
+
+  defp capability_gap_part(value) when is_binary(value), do: value
+  defp capability_gap_part(value) when is_map(value), do: Jason.encode!(value)
+  defp capability_gap_part(value) when is_list(value), do: Jason.encode!(value)
+  defp capability_gap_part(value) when is_nil(value), do: nil
+  defp capability_gap_part(value), do: inspect(value)
 
   defp schedule_tick(%State{} = state, delay_ms) when is_integer(delay_ms) and delay_ms >= 0 do
     if is_reference(state.tick_timer_ref) do

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -1205,6 +1205,82 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
+  test "app server emits skill_load_failed for Codex skill load errors" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-skill-load-failed-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-92B")
+      codex_binary = Path.join(test_root, "fake-codex")
+      File.mkdir_p!(workspace)
+
+      File.write!(codex_binary, """
+      #!/bin/sh
+      count=0
+      while IFS= read -r line; do
+        count=$((count + 1))
+
+        case "$count" in
+          1)
+            printf '%s\\n' '{"id":1,"result":{}}'
+            ;;
+          2)
+            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-92b"}}}'
+            ;;
+          3)
+            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-92b"}}}'
+            ;;
+          4)
+            printf '%s\\n' 'ERROR codex_core::codex: failed to load skill /tmp/missing/SKILL.md: No such file or directory' >&2
+            printf '%s\\n' '{"method":"turn/completed"}'
+            exit 0
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+      done
+      """)
+
+      File.chmod!(codex_binary, 0o755)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        codex_command: "#{codex_binary} app-server"
+      )
+
+      issue = %Issue{
+        id: "issue-skill-load-failed",
+        identifier: "MT-92B",
+        title: "Capture skill load failure",
+        description: "Ensure Codex skill load errors are surfaced to the orchestrator",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-92B",
+        labels: ["backend"]
+      }
+
+      test_pid = self()
+      on_message = fn message -> send(test_pid, {:app_server_message, message}) end
+
+      assert {:ok, _result} =
+               AppServer.run(workspace, "Capture skill load failure", issue, on_message: on_message)
+
+      assert_received {:app_server_message,
+                       %{
+                         event: :skill_load_failed,
+                         payload: "ERROR codex_core::codex: failed to load skill /tmp/missing/SKILL.md: No such file or directory"
+                       }}
+
+      assert_received {:app_server_message, %{event: :turn_completed}}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
   test "app server emits malformed events for JSON-like protocol lines that fail to decode" do
     test_root =
       Path.join(

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -626,6 +626,80 @@ defmodule SymphonyElixir.CoreTest do
     assert_due_in_range(due_at_ms, 99_000, 101_000)
   end
 
+  test "capability gap updates block the issue and stop the running agent" do
+    previous_memory_issues = Application.get_env(:symphony_elixir, :memory_tracker_issues)
+    previous_memory_recipient = Application.get_env(:symphony_elixir, :memory_tracker_recipient)
+    issue_id = "issue-capability-gap"
+    worker_pid = spawn(fn -> Process.sleep(:infinity) end)
+    ref = Process.monitor(worker_pid)
+    orchestrator_name = Module.concat(__MODULE__, :CapabilityGapOrchestrator)
+
+    try do
+      write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
+      Application.put_env(:symphony_elixir, :memory_tracker_recipient, self())
+
+      {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+      on_exit(fn ->
+        restore_app_env(:memory_tracker_issues, previous_memory_issues)
+        restore_app_env(:memory_tracker_recipient, previous_memory_recipient)
+
+        if Process.alive?(worker_pid), do: Process.exit(worker_pid, :kill)
+        if Process.alive?(pid), do: Process.exit(pid, :normal)
+      end)
+
+      initial_state = :sys.get_state(pid)
+
+      running_entry = %{
+        pid: worker_pid,
+        ref: ref,
+        identifier: "MT-564",
+        issue: %Issue{id: issue_id, identifier: "MT-564", state: "In Progress"},
+        session_id: nil,
+        worker_host: nil,
+        workspace_path: nil,
+        started_at: DateTime.utc_now()
+      }
+
+      :sys.replace_state(pid, fn _ ->
+        initial_state
+        |> Map.put(:running, %{issue_id => running_entry})
+        |> Map.put(:claimed, MapSet.new([issue_id]))
+        |> Map.put(:retry_attempts, %{})
+      end)
+
+      send(pid, {
+        :codex_worker_update,
+        issue_id,
+        %{
+          event: :tool_call_failed,
+          timestamp: DateTime.utc_now(),
+          tool_name: "linear_graphql",
+          result: %{
+            "success" => false,
+            "output" => ~s({"error":{"message":"Unsupported dynamic tool: \\"linear_create_issue\\"."}})
+          }
+        }
+      })
+
+      assert_receive {:memory_tracker_comment, ^issue_id, body}, 500
+      assert body =~ "Symphony blocked this issue"
+      assert body =~ "Missing capability: tool"
+      assert body =~ "Unsupported dynamic tool"
+      assert_receive {:memory_tracker_state_update, ^issue_id, "Blocked"}, 500
+
+      Process.sleep(50)
+      state = :sys.get_state(pid)
+      refute Map.has_key?(state.running, issue_id)
+      refute MapSet.member?(state.claimed, issue_id)
+      refute Map.has_key?(state.retry_attempts, issue_id)
+      refute Process.alive?(worker_pid)
+    after
+      restore_app_env(:memory_tracker_issues, previous_memory_issues)
+      restore_app_env(:memory_tracker_recipient, previous_memory_recipient)
+    end
+  end
+
   test "credit pause retry keeps waiting for the same non-terminal issue state" do
     previous_memory_issues = Application.get_env(:symphony_elixir, :memory_tracker_issues)
     issue_id = "issue-credit-resume"


### PR DESCRIPTION
## Summary

Closes #5.

This turns missing tools, skills, permissions, required approvals, and missing-user-input situations into explicit Symphony blockers. The orchestrator now stops the active issue and records the blocker instead of letting the agent continue spending turns on an impossible path.

## Implementation

- Extends Codex app-server event handling so relevant tool/skill/approval/input failures are surfaced to the orchestrator.
- Adds orchestrator capability-gap detection from those events.
- Moves affected issues into a blocked state with a clear explanation comment.
- Preserves ordinary tool success and non-capability failures on the existing paths.
- Adds app-server and orchestrator regression tests.

## Why config alone was insufficient

Raw Symphony hooks and workflow config do not receive the live Codex app-server event stream. Prompting agents to stop on missing capabilities is advisory, not enforced, and it still spends tokens before the model recognizes the issue. The orchestrator has to classify and stop these failures directly.

## Tests

```text
mix test test/symphony_elixir/app_server_test.exs test/symphony_elixir/core_test.exs
63 tests, 0 failures
```
