### PR TITLE
Support Backlog as a triage lane

### DIFF
--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -166,7 +166,7 @@ defmodule SymphonyElixir.AgentRunner do
   defp active_issue_state?(state_name) when is_binary(state_name) do
     normalized_state = normalize_issue_state(state_name)
 
-    Config.settings!().tracker.active_states
+    Config.tracker_dispatch_states()
     |> Enum.any?(fn active_state -> normalize_issue_state(active_state) == normalized_state end)
   end
 

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -6,6 +6,8 @@ defmodule SymphonyElixir.Config do
   alias SymphonyElixir.Config.Schema
   alias SymphonyElixir.Workflow
 
+  @backlog_state "Backlog"
+
   @default_prompt_template """
   You are working on a Linear issue.
 
@@ -60,6 +62,17 @@ defmodule SymphonyElixir.Config do
   end
 
   def max_concurrent_agents_for_state(_state_name), do: settings!().agent.max_concurrent_agents
+
+  @spec tracker_dispatch_states() :: [String.t()]
+  def tracker_dispatch_states do
+    tracker = settings!().tracker
+
+    if tracker.skip_backlog_triage do
+      Enum.uniq([@backlog_state | tracker.active_states])
+    else
+      tracker.active_states
+    end
+  end
 
   @spec codex_turn_sandbox_policy(Path.t() | nil) :: map()
   def codex_turn_sandbox_policy(workspace \\ nil) do

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -52,6 +52,7 @@ defmodule SymphonyElixir.Config.Schema do
       field(:assignee, :string)
       field(:active_states, {:array, :string}, default: ["Todo", "In Progress"])
       field(:terminal_states, {:array, :string}, default: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"])
+      field(:skip_backlog_triage, :boolean, default: false)
     end
 
     @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
@@ -59,7 +60,16 @@ defmodule SymphonyElixir.Config.Schema do
       schema
       |> cast(
         attrs,
-        [:kind, :endpoint, :api_key, :project_slug, :assignee, :active_states, :terminal_states],
+        [
+          :kind,
+          :endpoint,
+          :api_key,
+          :project_slug,
+          :assignee,
+          :active_states,
+          :terminal_states,
+          :skip_backlog_triage
+        ],
         empty_values: []
       )
     end

--- a/elixir/lib/symphony_elixir/linear/client.ex
+++ b/elixir/lib/symphony_elixir/linear/client.ex
@@ -117,7 +117,7 @@ defmodule SymphonyElixir.Linear.Client do
 
       true ->
         with {:ok, assignee_filter} <- routing_assignee_filter() do
-          do_fetch_by_states(project_slug, tracker.active_states, assignee_filter)
+          do_fetch_by_states(project_slug, Config.tracker_dispatch_states(), assignee_filter)
         end
     end
   end

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -712,7 +712,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp active_state_set do
-    Config.settings!().tracker.active_states
+    Config.tracker_dispatch_states()
     |> Enum.map(&normalize_issue_state/1)
     |> Enum.filter(&(&1 != ""))
     |> MapSet.new()

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -99,6 +99,7 @@ defmodule SymphonyElixir.TestSupport do
           tracker_assignee: nil,
           tracker_active_states: ["Todo", "In Progress"],
           tracker_terminal_states: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"],
+          tracker_skip_backlog_triage: false,
           poll_interval_ms: 30_000,
           workspace_root: Path.join(System.tmp_dir!(), "symphony_workspaces"),
           worker_ssh_hosts: [],
@@ -136,6 +137,7 @@ defmodule SymphonyElixir.TestSupport do
     tracker_assignee = Keyword.get(config, :tracker_assignee)
     tracker_active_states = Keyword.get(config, :tracker_active_states)
     tracker_terminal_states = Keyword.get(config, :tracker_terminal_states)
+    tracker_skip_backlog_triage = Keyword.get(config, :tracker_skip_backlog_triage)
     poll_interval_ms = Keyword.get(config, :poll_interval_ms)
     workspace_root = Keyword.get(config, :workspace_root)
     worker_ssh_hosts = Keyword.get(config, :worker_ssh_hosts)
@@ -174,6 +176,7 @@ defmodule SymphonyElixir.TestSupport do
         "  assignee: #{yaml_value(tracker_assignee)}",
         "  active_states: #{yaml_value(tracker_active_states)}",
         "  terminal_states: #{yaml_value(tracker_terminal_states)}",
+        "  skip_backlog_triage: #{yaml_value(tracker_skip_backlog_triage)}",
         "polling:",
         "  interval_ms: #{yaml_value(poll_interval_ms)}",
         "workspace:",

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -15,6 +15,8 @@ defmodule SymphonyElixir.CoreTest do
     assert config.polling.interval_ms == 30_000
     assert config.tracker.active_states == ["Todo", "In Progress"]
     assert config.tracker.terminal_states == ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]
+    assert config.tracker.skip_backlog_triage == false
+    assert Config.tracker_dispatch_states() == ["Todo", "In Progress"]
     assert config.tracker.assignee == nil
     assert config.agent.max_turns == 20
 
@@ -36,6 +38,10 @@ defmodule SymphonyElixir.CoreTest do
 
     write_workflow_file!(Workflow.workflow_file_path(), max_turns: 5)
     assert Config.settings!().agent.max_turns == 5
+
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_skip_backlog_triage: true)
+    assert Config.settings!().tracker.skip_backlog_triage == true
+    assert Config.tracker_dispatch_states() == ["Backlog", "Todo", "In Progress"]
 
     write_workflow_file!(Workflow.workflow_file_path(), tracker_active_states: "Todo,  Review,")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -538,6 +538,29 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     refute Orchestrator.should_dispatch_issue_for_test(issue, state)
   end
 
+  test "backlog issues require human triage unless skip_backlog_triage is enabled" do
+    state = %Orchestrator.State{
+      max_concurrent_agents: 3,
+      running: %{},
+      claimed: MapSet.new(),
+      codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      retry_attempts: %{}
+    }
+
+    issue = %Issue{
+      id: "backlog-1",
+      identifier: "MT-1008",
+      title: "Needs triage",
+      state: "Backlog"
+    }
+
+    refute Orchestrator.should_dispatch_issue_for_test(issue, state)
+
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_skip_backlog_triage: true)
+
+    assert Orchestrator.should_dispatch_issue_for_test(issue, state)
+  end
+
   test "todo issue with terminal blockers remains dispatch-eligible" do
     state = %Orchestrator.State{
       max_concurrent_agents: 3,


### PR DESCRIPTION
## Summary

Closes #7.

This adds an explicit `tracker.skip_backlog_triage` flag so teams can keep Backlog as an intake lane without making it a Symphony pickup state by default.

## Implementation

- Adds `skip_backlog_triage` to tracker configuration.
- Adds `Config.tracker_dispatch_states/0` as the canonical pickup-state accessor.
- Keeps Backlog out of dispatch unless `skip_backlog_triage: true` is configured.
- Updates tracker polling paths to use dispatch states instead of raw active states.
- Adds tests for default triage behavior and explicit opt-out.

## Why config alone was insufficient

Raw Symphony only offered `active_states`. Including Backlog made it dispatchable; excluding Backlog made it triage-only. There was no named, auditable flag representing the workflow decision.

## Tests

```text
mix test test/symphony_elixir/core_test.exs test/symphony_elixir/workspace_and_config_test.exs
90 tests, 0 failures
```
