### PR TITLE
Separate pickup states from continuation states

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -575,6 +575,8 @@ not require recognizing or validating extension fields unless that extension is 
 - `tracker.api_key`: string or `$VAR`, canonical env `LINEAR_API_KEY` when `tracker.kind=linear`
 - `tracker.project_slug`: string, REQUIRED when `tracker.kind=linear`
 - `tracker.active_states`: list of strings, default `["Todo", "In Progress"]`
+- `tracker.continuation_states`: optional list of strings for already-running sessions; defaults to
+  dispatch states when omitted
 - `tracker.terminal_states`: list of strings, default `["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]`
 - `polling.interval_ms`: integer, default `30000`
 - `workspace.root`: path resolved to absolute, default `<system-temp>/symphony_workspaces`
@@ -720,6 +722,8 @@ An issue is dispatch-eligible only if all are true:
 
 - It has `id`, `identifier`, `title`, and `state`.
 - Its state is in `active_states` and not in `terminal_states`.
+- `continuation_states` do not make new issues dispatch-eligible; they only keep an already-running
+  session alive while a workflow moves through intermediate states such as `In Progress` or review.
 - It is not already in `running`.
 - It is not already in `claimed`.
 - Global concurrency slots are available.
@@ -1595,7 +1599,8 @@ Operators can control behavior by:
   Section 6.2.
 - Changing issue states in the tracker:
   - terminal state -> running session is stopped and workspace cleaned when reconciled
-  - non-active state -> running session is stopped without cleanup
+  - continuation state -> running session is kept alive and its issue snapshot is refreshed
+  - state outside continuation states -> running session is stopped without cleanup
 - Restarting the service for process recovery or deployment (not as the normal path for applying
   workflow config changes).
 
@@ -1755,7 +1760,7 @@ function reconcile_running_issues(state):
   for issue in refreshed:
     if issue.state in terminal_states:
       state = terminate_running_issue(state, issue.id, cleanup_workspace=true)
-    else if issue.state in active_states:
+    else if issue.state in continuation_states:
       state.running[issue.id].issue = issue
     else:
       state = terminate_running_issue(state, issue.id, cleanup_workspace=false)

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -83,6 +83,12 @@ Optional flags:
 The `WORKFLOW.md` file uses YAML front matter for configuration, plus a Markdown body used as the
 Codex session prompt.
 
+Tracker state configuration separates new dispatch from existing session continuation:
+
+- `tracker.active_states` controls which issues can start a new worker.
+- `tracker.continuation_states` controls which non-terminal states keep an already-running worker
+  alive, for example while an issue moves from implementation into review.
+
 Minimal example:
 
 ```md

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -7,6 +7,12 @@ tracker:
     - In Progress
     - Merging
     - Rework
+  continuation_states:
+    - Todo
+    - In Progress
+    - Human Review
+    - Merging
+    - Rework
   terminal_states:
     - Closed
     - Cancelled

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -74,6 +74,12 @@ defmodule SymphonyElixir.Config do
     end
   end
 
+  @spec tracker_continuation_states() :: [String.t()]
+  def tracker_continuation_states do
+    tracker = settings!().tracker
+    tracker.continuation_states || tracker_dispatch_states()
+  end
+
   @spec codex_turn_sandbox_policy(Path.t() | nil) :: map()
   def codex_turn_sandbox_policy(workspace \\ nil) do
     case Schema.resolve_runtime_turn_sandbox_policy(settings!(), workspace) do

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -51,7 +51,12 @@ defmodule SymphonyElixir.Config.Schema do
       field(:project_slug, :string)
       field(:assignee, :string)
       field(:active_states, {:array, :string}, default: ["Todo", "In Progress"])
-      field(:terminal_states, {:array, :string}, default: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"])
+      field(:continuation_states, {:array, :string})
+
+      field(:terminal_states, {:array, :string},
+        default: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]
+      )
+
       field(:skip_backlog_triage, :boolean, default: false)
     end
 
@@ -67,6 +72,7 @@ defmodule SymphonyElixir.Config.Schema do
           :project_slug,
           :assignee,
           :active_states,
+          :continuation_states,
           :terminal_states,
           :skip_backlog_triage
         ],
@@ -149,7 +155,12 @@ defmodule SymphonyElixir.Config.Schema do
       schema
       |> cast(
         attrs,
-        [:max_concurrent_agents, :max_turns, :max_retry_backoff_ms, :max_concurrent_agents_by_state],
+        [
+          :max_concurrent_agents,
+          :max_turns,
+          :max_retry_backoff_ms,
+          :max_concurrent_agents_by_state
+        ],
         empty_values: []
       )
       |> validate_number(:max_concurrent_agents, greater_than: 0)
@@ -226,7 +237,9 @@ defmodule SymphonyElixir.Config.Schema do
     @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
     def changeset(schema, attrs) do
       schema
-      |> cast(attrs, [:after_create, :before_run, :after_run, :before_remove, :timeout_ms], empty_values: [])
+      |> cast(attrs, [:after_create, :before_run, :after_run, :before_remove, :timeout_ms],
+        empty_values: []
+      )
       |> validate_number(:timeout_ms, greater_than: 0)
     end
   end
@@ -378,13 +391,19 @@ defmodule SymphonyElixir.Config.Schema do
   defp finalize_settings(settings) do
     tracker = %{
       settings.tracker
-      | api_key: resolve_secret_setting(settings.tracker.api_key, System.get_env("LINEAR_API_KEY")),
-        assignee: resolve_secret_setting(settings.tracker.assignee, System.get_env("LINEAR_ASSIGNEE"))
+      | api_key:
+          resolve_secret_setting(settings.tracker.api_key, System.get_env("LINEAR_API_KEY")),
+        assignee:
+          resolve_secret_setting(settings.tracker.assignee, System.get_env("LINEAR_ASSIGNEE"))
     }
 
     workspace = %{
       settings.workspace
-      | root: resolve_path_value(settings.workspace.root, Path.join(System.tmp_dir!(), "symphony_workspaces"))
+      | root:
+          resolve_path_value(
+            settings.workspace.root,
+            Path.join(System.tmp_dir!(), "symphony_workspaces")
+          )
     }
 
     codex = %{
@@ -532,7 +551,11 @@ defmodule SymphonyElixir.Config.Schema do
   end
 
   defp git_metadata_root(workspace_root, git_rev_parse_arg) do
-    case System.cmd("git", ["-C", workspace_root, "rev-parse", "--path-format=absolute", git_rev_parse_arg], stderr_to_stdout: true) do
+    case System.cmd(
+           "git",
+           ["-C", workspace_root, "rev-parse", "--path-format=absolute", git_rev_parse_arg],
+           stderr_to_stdout: true
+         ) do
       {path, 0} ->
         path
         |> String.trim()

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -137,11 +137,15 @@ defmodule SymphonyElixir.Orchestrator do
           case reason do
             :normal ->
               if credit_exhausted_running_entry?(running_entry) do
-                Logger.warning("Agent task paused for issue_id=#{issue_id} session_id=#{session_id}; Codex credits are exhausted")
+                Logger.warning(
+                  "Agent task paused for issue_id=#{issue_id} session_id=#{session_id}; Codex credits are exhausted"
+                )
 
                 schedule_credit_exhausted_retry(state, issue_id, running_entry)
               else
-                Logger.info("Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling active-state continuation check")
+                Logger.info(
+                  "Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling active-state continuation check"
+                )
 
                 state
                 |> complete_issue(issue_id)
@@ -154,12 +158,17 @@ defmodule SymphonyElixir.Orchestrator do
               end
 
             _ ->
-              if credit_exhausted_running_entry?(running_entry) or credit_exhausted_reason?(reason) do
-                Logger.warning("Agent task paused for issue_id=#{issue_id} session_id=#{session_id}; Codex credits appear exhausted reason=#{inspect(reason)}")
+              if credit_exhausted_running_entry?(running_entry) or
+                   credit_exhausted_reason?(reason) do
+                Logger.warning(
+                  "Agent task paused for issue_id=#{issue_id} session_id=#{session_id}; Codex credits appear exhausted reason=#{inspect(reason)}"
+                )
 
                 schedule_credit_exhausted_retry(state, issue_id, running_entry)
               else
-                Logger.warning("Agent task exited for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}; scheduling retry")
+                Logger.warning(
+                  "Agent task exited for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}; scheduling retry"
+                )
 
                 next_attempt = next_retry_attempt_from_running(running_entry)
 
@@ -172,7 +181,9 @@ defmodule SymphonyElixir.Orchestrator do
               end
           end
 
-        Logger.info("Agent task finished for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}")
+        Logger.info(
+          "Agent task finished for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}"
+        )
 
         notify_dashboard()
         {:noreply, state}
@@ -220,7 +231,12 @@ defmodule SymphonyElixir.Orchestrator do
               state
 
             capability_gap ->
-              block_issue_for_capability_gap(state, issue_id, updated_running_entry, capability_gap)
+              block_issue_for_capability_gap(
+                state,
+                issue_id,
+                updated_running_entry,
+                capability_gap
+              )
           end
 
         notify_dashboard()
@@ -311,13 +327,15 @@ defmodule SymphonyElixir.Orchestrator do
           issues
           |> reconcile_running_issue_states(
             state,
-            active_state_set(),
+            continuation_state_set(),
             terminal_state_set()
           )
           |> reconcile_missing_running_issue_ids(running_ids, issues)
 
         {:error, reason} ->
-          Logger.debug("Failed to refresh running issue states: #{inspect(reason)}; keeping active workers")
+          Logger.debug(
+            "Failed to refresh running issue states: #{inspect(reason)}; keeping active workers"
+          )
 
           state
       end
@@ -327,12 +345,16 @@ defmodule SymphonyElixir.Orchestrator do
   @doc false
   @spec reconcile_issue_states_for_test([Issue.t()], term()) :: term()
   def reconcile_issue_states_for_test(issues, %State{} = state) when is_list(issues) do
-    reconcile_running_issue_states(issues, state, active_state_set(), terminal_state_set())
+    reconcile_running_issue_states(issues, state, continuation_state_set(), terminal_state_set())
   end
 
   def reconcile_issue_states_for_test(issues, state) when is_list(issues) do
-    reconcile_running_issue_states(issues, state, active_state_set(), terminal_state_set())
+    reconcile_running_issue_states(issues, state, continuation_state_set(), terminal_state_set())
   end
+
+  @doc false
+  @spec reconcile_running_issues_for_test(term()) :: term()
+  def reconcile_running_issues_for_test(%State{} = state), do: reconcile_running_issues(state)
 
   @doc false
   @spec should_dispatch_issue_for_test(Issue.t(), term()) :: boolean()
@@ -355,7 +377,8 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   @doc false
-  @spec select_worker_host_for_test(term(), String.t() | nil) :: String.t() | nil | :no_worker_capacity
+  @spec select_worker_host_for_test(term(), String.t() | nil) ::
+          String.t() | nil | :no_worker_capacity
   def select_worker_host_for_test(%State{} = state, preferred_worker_host) do
     select_worker_host(state, preferred_worker_host)
   end
@@ -374,12 +397,16 @@ defmodule SymphonyElixir.Orchestrator do
   defp reconcile_issue_state(%Issue{} = issue, state, active_states, terminal_states) do
     cond do
       terminal_issue_state?(issue.state, terminal_states) ->
-        Logger.info("Issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; stopping active agent")
+        Logger.info(
+          "Issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; stopping active agent"
+        )
 
         terminate_running_issue(state, issue.id, true)
 
       !issue_routable_to_worker?(issue) ->
-        Logger.info("Issue no longer routed to this worker: #{issue_context(issue)} assignee=#{inspect(issue.assignee_id)}; stopping active agent")
+        Logger.info(
+          "Issue no longer routed to this worker: #{issue_context(issue)} assignee=#{inspect(issue.assignee_id)}; stopping active agent"
+        )
 
         terminate_running_issue(state, issue.id, false)
 
@@ -387,7 +414,9 @@ defmodule SymphonyElixir.Orchestrator do
         refresh_running_issue_state(state, issue)
 
       true ->
-        Logger.info("Issue moved to non-active state: #{issue_context(issue)} state=#{issue.state}; stopping active agent")
+        Logger.info(
+          "Issue moved to non-active state: #{issue_context(issue)} state=#{issue.state}; stopping active agent"
+        )
 
         terminate_running_issue(state, issue.id, false)
     end
@@ -420,10 +449,14 @@ defmodule SymphonyElixir.Orchestrator do
   defp log_missing_running_issue(%State{} = state, issue_id) when is_binary(issue_id) do
     case Map.get(state.running, issue_id) do
       %{identifier: identifier} ->
-        Logger.info("Issue no longer visible during running-state refresh: issue_id=#{issue_id} issue_identifier=#{identifier}; stopping active agent")
+        Logger.info(
+          "Issue no longer visible during running-state refresh: issue_id=#{issue_id} issue_identifier=#{identifier}; stopping active agent"
+        )
 
       _ ->
-        Logger.info("Issue no longer visible during running-state refresh: issue_id=#{issue_id}; stopping active agent")
+        Logger.info(
+          "Issue no longer visible during running-state refresh: issue_id=#{issue_id}; stopping active agent"
+        )
     end
   end
 
@@ -481,15 +514,21 @@ defmodule SymphonyElixir.Orchestrator do
         :ok
 
       {:error, reason} ->
-        Logger.warning("Failed to comment capability gap for issue_id=#{issue_id} issue_identifier=#{identifier}: #{inspect(reason)}")
+        Logger.warning(
+          "Failed to comment capability gap for issue_id=#{issue_id} issue_identifier=#{identifier}: #{inspect(reason)}"
+        )
     end
 
     case Tracker.update_issue_state(issue_id, @blocked_state_name) do
       :ok ->
-        Logger.warning("Blocked issue after agent capability gap: issue_id=#{issue_id} issue_identifier=#{identifier} missing=#{kind}")
+        Logger.warning(
+          "Blocked issue after agent capability gap: issue_id=#{issue_id} issue_identifier=#{identifier} missing=#{kind}"
+        )
 
       {:error, reason} ->
-        Logger.warning("Failed to move capability gap issue to #{@blocked_state_name}: issue_id=#{issue_id} issue_identifier=#{identifier} reason=#{inspect(reason)}")
+        Logger.warning(
+          "Failed to move capability gap issue to #{@blocked_state_name}: issue_id=#{issue_id} issue_identifier=#{identifier} reason=#{inspect(reason)}"
+        )
     end
 
     terminate_running_issue(state, issue_id, false)
@@ -532,7 +571,9 @@ defmodule SymphonyElixir.Orchestrator do
       identifier = Map.get(running_entry, :identifier, issue_id)
       session_id = running_entry_session_id(running_entry)
 
-      Logger.warning("Issue stalled: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; restarting with backoff")
+      Logger.warning(
+        "Issue stalled: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; restarting with backoff"
+      )
 
       next_attempt = next_retry_attempt_from_running(running_entry)
 
@@ -595,7 +636,8 @@ defmodule SymphonyElixir.Orchestrator do
   defp sort_issues_for_dispatch(issues) when is_list(issues) do
     Enum.sort_by(issues, fn
       %Issue{} = issue ->
-        {priority_rank(issue.priority), issue_created_at_sort_key(issue), issue.identifier || issue.id || ""}
+        {priority_rank(issue.priority), issue_created_at_sort_key(issue),
+         issue.identifier || issue.id || ""}
 
       _ ->
         {priority_rank(nil), issue_created_at_sort_key(nil), ""}
@@ -718,22 +760,41 @@ defmodule SymphonyElixir.Orchestrator do
     |> MapSet.new()
   end
 
+  defp continuation_state_set do
+    Config.tracker_continuation_states()
+    |> Enum.map(&normalize_issue_state/1)
+    |> Enum.filter(&(&1 != ""))
+    |> MapSet.new()
+  end
+
   defp dispatch_issue(%State{} = state, issue, attempt \\ nil, preferred_worker_host \\ nil) do
-    case revalidate_issue_for_dispatch(issue, &Tracker.fetch_issue_states_by_ids/1, terminal_state_set()) do
+    case revalidate_issue_for_dispatch(
+           issue,
+           &Tracker.fetch_issue_states_by_ids/1,
+           terminal_state_set()
+         ) do
       {:ok, %Issue{} = refreshed_issue} ->
         do_dispatch_issue(state, refreshed_issue, attempt, preferred_worker_host)
 
       {:skip, :missing} ->
-        Logger.info("Skipping dispatch; issue no longer active or visible: #{issue_context(issue)}")
+        Logger.info(
+          "Skipping dispatch; issue no longer active or visible: #{issue_context(issue)}"
+        )
+
         state
 
       {:skip, %Issue{} = refreshed_issue} ->
-        Logger.info("Skipping stale dispatch after issue refresh: #{issue_context(refreshed_issue)} state=#{inspect(refreshed_issue.state)} blocked_by=#{length(refreshed_issue.blocked_by)}")
+        Logger.info(
+          "Skipping stale dispatch after issue refresh: #{issue_context(refreshed_issue)} state=#{inspect(refreshed_issue.state)} blocked_by=#{length(refreshed_issue.blocked_by)}"
+        )
 
         state
 
       {:error, reason} ->
-        Logger.warning("Skipping dispatch; issue refresh failed for #{issue_context(issue)}: #{inspect(reason)}")
+        Logger.warning(
+          "Skipping dispatch; issue refresh failed for #{issue_context(issue)}: #{inspect(reason)}"
+        )
+
         state
     end
   end
@@ -743,7 +804,10 @@ defmodule SymphonyElixir.Orchestrator do
 
     case select_worker_host(state, preferred_worker_host) do
       :no_worker_capacity ->
-        Logger.debug("No SSH worker slots available for #{issue_context(issue)} preferred_worker_host=#{inspect(preferred_worker_host)}")
+        Logger.debug(
+          "No SSH worker slots available for #{issue_context(issue)} preferred_worker_host=#{inspect(preferred_worker_host)}"
+        )
+
         state
 
       worker_host ->
@@ -758,7 +822,9 @@ defmodule SymphonyElixir.Orchestrator do
       {:ok, pid} ->
         ref = Process.monitor(pid)
 
-        Logger.info("Dispatching issue to agent: #{issue_context(issue)} pid=#{inspect(pid)} attempt=#{inspect(attempt)} worker_host=#{worker_host || "local"}")
+        Logger.info(
+          "Dispatching issue to agent: #{issue_context(issue)} pid=#{inspect(pid)} attempt=#{inspect(attempt)} worker_host=#{worker_host || "local"}"
+        )
 
         running =
           Map.put(state.running, issue.id, %{
@@ -868,7 +934,9 @@ defmodule SymphonyElixir.Orchestrator do
 
     error_suffix = if is_binary(error), do: " error=#{error}", else: ""
 
-    Logger.warning("Retrying issue_id=#{issue_id} issue_identifier=#{identifier} in #{delay_ms}ms (attempt #{next_attempt})#{error_suffix}")
+    Logger.warning(
+      "Retrying issue_id=#{issue_id} issue_identifier=#{identifier} in #{delay_ms}ms (attempt #{next_attempt})#{error_suffix}"
+    )
 
     %{
       state
@@ -889,7 +957,8 @@ defmodule SymphonyElixir.Orchestrator do
     }
   end
 
-  defp pop_retry_attempt_state(%State{} = state, issue_id, retry_token) when is_reference(retry_token) do
+  defp pop_retry_attempt_state(%State{} = state, issue_id, retry_token)
+       when is_reference(retry_token) do
     case Map.get(state.retry_attempts, issue_id) do
       %{attempt: attempt, retry_token: ^retry_token} = retry_entry ->
         metadata = %{
@@ -902,7 +971,8 @@ defmodule SymphonyElixir.Orchestrator do
           workspace_path: Map.get(retry_entry, :workspace_path)
         }
 
-        {:ok, attempt, metadata, %{state | retry_attempts: Map.delete(state.retry_attempts, issue_id)}}
+        {:ok, attempt, metadata,
+         %{state | retry_attempts: Map.delete(state.retry_attempts, issue_id)}}
 
       _ ->
         :missing
@@ -917,7 +987,9 @@ defmodule SymphonyElixir.Orchestrator do
         |> handle_retry_issue_lookup(state, issue_id, attempt, metadata)
 
       {:error, reason} ->
-        Logger.warning("Retry poll failed for issue_id=#{issue_id} issue_identifier=#{metadata[:identifier] || issue_id}: #{inspect(reason)}")
+        Logger.warning(
+          "Retry poll failed for issue_id=#{issue_id} issue_identifier=#{metadata[:identifier] || issue_id}: #{inspect(reason)}"
+        )
 
         {:noreply,
          schedule_issue_retry(
@@ -934,19 +1006,24 @@ defmodule SymphonyElixir.Orchestrator do
 
     cond do
       terminal_issue_state?(issue.state, terminal_states) ->
-        Logger.info("Issue state is terminal: issue_id=#{issue_id} issue_identifier=#{issue.identifier} state=#{issue.state}; removing associated workspace")
+        Logger.info(
+          "Issue state is terminal: issue_id=#{issue_id} issue_identifier=#{issue.identifier} state=#{issue.state}; removing associated workspace"
+        )
 
         cleanup_issue_workspace(issue.identifier, metadata[:worker_host])
         {:noreply, release_issue_claim(state, issue_id)}
 
-      credit_exhausted_retry?(metadata) and credit_pause_resume_candidate_issue?(issue, metadata, terminal_states) ->
+      credit_exhausted_retry?(metadata) and
+          credit_pause_resume_candidate_issue?(issue, metadata, terminal_states) ->
         handle_credit_pause_retry(state, issue, attempt, metadata)
 
       retry_candidate_issue?(issue, terminal_states) ->
         handle_active_retry(state, issue, attempt, metadata)
 
       true ->
-        Logger.debug("Issue left active states, removing claim issue_id=#{issue_id} issue_identifier=#{issue.identifier}")
+        Logger.debug(
+          "Issue left active states, removing claim issue_id=#{issue_id} issue_identifier=#{issue.identifier}"
+        )
 
         {:noreply, release_issue_claim(state, issue_id)}
     end
@@ -978,7 +1055,9 @@ defmodule SymphonyElixir.Orchestrator do
         end)
 
       {:error, reason} ->
-        Logger.warning("Skipping startup terminal workspace cleanup; failed to fetch terminal issues: #{inspect(reason)}")
+        Logger.warning(
+          "Skipping startup terminal workspace cleanup; failed to fetch terminal issues: #{inspect(reason)}"
+        )
     end
   end
 
@@ -1008,11 +1087,17 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp handle_credit_pause_retry(state, issue, attempt, metadata) do
-    if dispatch_slots_available?(issue, state) and worker_slots_available?(state, metadata[:worker_host]) do
-      Logger.info("Retrying issue after Codex credit pause: #{issue_context(issue)} state=#{issue.state}")
+    if dispatch_slots_available?(issue, state) and
+         worker_slots_available?(state, metadata[:worker_host]) do
+      Logger.info(
+        "Retrying issue after Codex credit pause: #{issue_context(issue)} state=#{issue.state}"
+      )
+
       {:noreply, do_dispatch_issue(state, issue, attempt, metadata[:worker_host])}
     else
-      Logger.debug("No available slots for retrying credit-paused #{issue_context(issue)}; retrying again")
+      Logger.debug(
+        "No available slots for retrying credit-paused #{issue_context(issue)}; retrying again"
+      )
 
       {:noreply,
        schedule_issue_retry(
@@ -1031,7 +1116,8 @@ defmodule SymphonyElixir.Orchestrator do
     %{state | claimed: MapSet.delete(state.claimed, issue_id)}
   end
 
-  defp retry_delay(attempt, metadata) when is_integer(attempt) and attempt > 0 and is_map(metadata) do
+  defp retry_delay(attempt, metadata)
+       when is_integer(attempt) and attempt > 0 and is_map(metadata) do
     cond do
       metadata[:delay_type] == :continuation and attempt == 1 ->
         @continuation_retry_delay_ms
@@ -1046,7 +1132,11 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp failure_retry_delay(attempt) do
     max_delay_power = min(attempt - 1, 10)
-    min(@failure_retry_base_ms * (1 <<< max_delay_power), Config.settings!().agent.max_retry_backoff_ms)
+
+    min(
+      @failure_retry_base_ms * (1 <<< max_delay_power),
+      Config.settings!().agent.max_retry_backoff_ms
+    )
   end
 
   defp credit_retry_delay(delay_ms) when is_integer(delay_ms) and delay_ms > 0 do
@@ -1124,7 +1214,8 @@ defmodule SymphonyElixir.Orchestrator do
     |> elem(0)
   end
 
-  defp running_worker_host_count(running, worker_host) when is_map(running) and is_binary(worker_host) do
+  defp running_worker_host_count(running, worker_host)
+       when is_map(running) and is_binary(worker_host) do
     Enum.count(running, fn
       {_issue_id, %{worker_host: ^worker_host}} -> true
       _ -> false
@@ -1391,7 +1482,8 @@ defmodule SymphonyElixir.Orchestrator do
         end
 
       _ ->
-        {Map.get(running_entry, :credit_exhausted, false), Map.get(running_entry, :credit_retry_delay_ms)}
+        {Map.get(running_entry, :credit_exhausted, false),
+         Map.get(running_entry, :credit_retry_delay_ms)}
     end
   end
 
@@ -1497,7 +1589,8 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp capability_gap_from_update(%{event: :turn_input_required} = update) do
-    {:permission, "Codex required interactive input during an unattended run: #{update_text(update)}"}
+    {:permission,
+     "Codex required interactive input during an unattended run: #{update_text(update)}"}
   end
 
   defp capability_gap_from_update(%{event: :unsupported_tool_call} = update) do
@@ -1508,7 +1601,9 @@ defmodule SymphonyElixir.Orchestrator do
   defp capability_gap_from_update(%{event: :tool_call_failed} = update) do
     if capability_gap_text?(update_text(update)) do
       tool_name = update[:tool_name] || "<unknown>"
-      {:tool, "Tool call failed because a capability appears unavailable: #{tool_name}. #{update_text(update)}"}
+
+      {:tool,
+       "Tool call failed because a capability appears unavailable: #{tool_name}. #{update_text(update)}"}
     end
   end
 
@@ -1621,7 +1716,8 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp credit_pause_resume_candidate_issue?(_issue, _metadata, _terminal_states), do: false
 
-  defp same_issue_state?(state_name, expected_state) when is_binary(state_name) and is_binary(expected_state) do
+  defp same_issue_state?(state_name, expected_state)
+       when is_binary(state_name) and is_binary(expected_state) do
     normalize_issue_state(state_name) == normalize_issue_state(expected_state)
   end
 

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -22,7 +22,12 @@ defmodule SymphonyElixir.TestSupport do
       alias SymphonyElixir.Workspace
 
       import SymphonyElixir.TestSupport,
-        only: [write_workflow_file!: 1, write_workflow_file!: 2, restore_env: 2, stop_default_http_server: 0]
+        only: [
+          write_workflow_file!: 1,
+          write_workflow_file!: 2,
+          restore_env: 2,
+          stop_default_http_server: 0
+        ]
 
       setup do
         workflow_root =
@@ -35,7 +40,10 @@ defmodule SymphonyElixir.TestSupport do
         workflow_file = Path.join(workflow_root, "WORKFLOW.md")
         write_workflow_file!(workflow_file)
         Workflow.set_workflow_file_path(workflow_file)
-        if Process.whereis(SymphonyElixir.WorkflowStore), do: SymphonyElixir.WorkflowStore.force_reload()
+
+        if Process.whereis(SymphonyElixir.WorkflowStore),
+          do: SymphonyElixir.WorkflowStore.force_reload()
+
         stop_default_http_server()
 
         on_exit(fn ->
@@ -98,6 +106,7 @@ defmodule SymphonyElixir.TestSupport do
           tracker_project_slug: "project",
           tracker_assignee: nil,
           tracker_active_states: ["Todo", "In Progress"],
+          tracker_continuation_states: nil,
           tracker_terminal_states: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"],
           tracker_skip_backlog_triage: false,
           poll_interval_ms: 30_000,
@@ -109,7 +118,9 @@ defmodule SymphonyElixir.TestSupport do
           max_retry_backoff_ms: 300_000,
           max_concurrent_agents_by_state: %{},
           codex_command: "codex app-server",
-          codex_approval_policy: %{reject: %{sandbox_approval: true, rules: true, mcp_elicitations: true}},
+          codex_approval_policy: %{
+            reject: %{sandbox_approval: true, rules: true, mcp_elicitations: true}
+          },
           codex_thread_sandbox: "workspace-write",
           codex_turn_sandbox_policy: nil,
           codex_turn_timeout_ms: 3_600_000,
@@ -136,12 +147,16 @@ defmodule SymphonyElixir.TestSupport do
     tracker_project_slug = Keyword.get(config, :tracker_project_slug)
     tracker_assignee = Keyword.get(config, :tracker_assignee)
     tracker_active_states = Keyword.get(config, :tracker_active_states)
+    tracker_continuation_states = Keyword.get(config, :tracker_continuation_states)
     tracker_terminal_states = Keyword.get(config, :tracker_terminal_states)
     tracker_skip_backlog_triage = Keyword.get(config, :tracker_skip_backlog_triage)
     poll_interval_ms = Keyword.get(config, :poll_interval_ms)
     workspace_root = Keyword.get(config, :workspace_root)
     worker_ssh_hosts = Keyword.get(config, :worker_ssh_hosts)
-    worker_max_concurrent_agents_per_host = Keyword.get(config, :worker_max_concurrent_agents_per_host)
+
+    worker_max_concurrent_agents_per_host =
+      Keyword.get(config, :worker_max_concurrent_agents_per_host)
+
     max_concurrent_agents = Keyword.get(config, :max_concurrent_agents)
     max_turns = Keyword.get(config, :max_turns)
     max_retry_backoff_ms = Keyword.get(config, :max_retry_backoff_ms)
@@ -175,6 +190,7 @@ defmodule SymphonyElixir.TestSupport do
         "  project_slug: #{yaml_value(tracker_project_slug)}",
         "  assignee: #{yaml_value(tracker_assignee)}",
         "  active_states: #{yaml_value(tracker_active_states)}",
+        "  continuation_states: #{yaml_value(tracker_continuation_states)}",
         "  terminal_states: #{yaml_value(tracker_terminal_states)}",
         "  skip_backlog_triage: #{yaml_value(tracker_skip_backlog_triage)}",
         "polling:",
@@ -195,8 +211,18 @@ defmodule SymphonyElixir.TestSupport do
         "  turn_timeout_ms: #{yaml_value(codex_turn_timeout_ms)}",
         "  read_timeout_ms: #{yaml_value(codex_read_timeout_ms)}",
         "  stall_timeout_ms: #{yaml_value(codex_stall_timeout_ms)}",
-        hooks_yaml(hook_after_create, hook_before_run, hook_after_run, hook_before_remove, hook_timeout_ms),
-        observability_yaml(observability_enabled, observability_refresh_ms, observability_render_interval_ms),
+        hooks_yaml(
+          hook_after_create,
+          hook_before_run,
+          hook_after_run,
+          hook_before_remove,
+          hook_timeout_ms
+        ),
+        observability_yaml(
+          observability_enabled,
+          observability_refresh_ms,
+          observability_render_interval_ms
+        ),
         server_yaml(server_port, server_host),
         "---",
         prompt
@@ -228,9 +254,16 @@ defmodule SymphonyElixir.TestSupport do
 
   defp yaml_value(value), do: yaml_value(to_string(value))
 
-  defp hooks_yaml(nil, nil, nil, nil, timeout_ms), do: "hooks:\n  timeout_ms: #{yaml_value(timeout_ms)}"
+  defp hooks_yaml(nil, nil, nil, nil, timeout_ms),
+    do: "hooks:\n  timeout_ms: #{yaml_value(timeout_ms)}"
 
-  defp hooks_yaml(hook_after_create, hook_before_run, hook_after_run, hook_before_remove, timeout_ms) do
+  defp hooks_yaml(
+         hook_after_create,
+         hook_before_run,
+         hook_after_run,
+         hook_before_remove,
+         timeout_ms
+       ) do
     [
       "hooks:",
       "  timeout_ms: #{yaml_value(timeout_ms)}",

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -14,9 +14,19 @@ defmodule SymphonyElixir.CoreTest do
     config = Config.settings!()
     assert config.polling.interval_ms == 30_000
     assert config.tracker.active_states == ["Todo", "In Progress"]
-    assert config.tracker.terminal_states == ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]
+    assert config.tracker.continuation_states == nil
+
+    assert config.tracker.terminal_states == [
+             "Closed",
+             "Cancelled",
+             "Canceled",
+             "Duplicate",
+             "Done"
+           ]
+
     assert config.tracker.skip_backlog_triage == false
     assert Config.tracker_dispatch_states() == ["Todo", "In Progress"]
+    assert Config.tracker_continuation_states() == ["Todo", "In Progress"]
     assert config.tracker.assignee == nil
     assert config.agent.max_turns == 20
 
@@ -42,6 +52,21 @@ defmodule SymphonyElixir.CoreTest do
     write_workflow_file!(Workflow.workflow_file_path(), tracker_skip_backlog_triage: true)
     assert Config.settings!().tracker.skip_backlog_triage == true
     assert Config.tracker_dispatch_states() == ["Backlog", "Todo", "In Progress"]
+    assert Config.tracker_continuation_states() == ["Backlog", "Todo", "In Progress"]
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_active_states: ["Todo", "Approved"],
+      tracker_continuation_states: ["Todo", "Approved", "In Progress", "In Review"]
+    )
+
+    assert Config.tracker_dispatch_states() == ["Todo", "Approved"]
+
+    assert Config.tracker_continuation_states() == [
+             "Todo",
+             "Approved",
+             "In Progress",
+             "In Review"
+           ]
 
     write_workflow_file!(Workflow.workflow_file_path(), tracker_active_states: "Todo,  Review,")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
@@ -70,7 +95,10 @@ defmodule SymphonyElixir.CoreTest do
     write_workflow_file!(Workflow.workflow_file_path(), codex_command: "/bin/sh app-server")
     assert :ok = Config.validate!()
 
-    write_workflow_file!(Workflow.workflow_file_path(), codex_approval_policy: "definitely-not-valid")
+    write_workflow_file!(Workflow.workflow_file_path(),
+      codex_approval_policy: "definitely-not-valid"
+    )
+
     assert :ok = Config.validate!()
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_thread_sandbox: "unsafe-ish")
@@ -111,10 +139,15 @@ defmodule SymphonyElixir.CoreTest do
 
     hooks = Map.get(config, "hooks", %{})
     assert is_map(hooks)
-    assert Map.get(hooks, "after_create") =~ "git clone --depth 1 https://github.com/openai/symphony ."
+
+    assert Map.get(hooks, "after_create") =~
+             "git clone --depth 1 https://github.com/openai/symphony ."
+
     assert Map.get(hooks, "after_create") =~ "cd elixir && mise trust"
     assert Map.get(hooks, "after_create") =~ "mise exec -- mix deps.get"
-    assert Map.get(hooks, "before_remove") =~ "cd elixir && mise exec -- mix workspace.before_remove"
+
+    assert Map.get(hooks, "before_remove") =~
+             "cd elixir && mise exec -- mix workspace.before_remove"
 
     assert String.trim(prompt) != ""
     assert is_binary(Config.workflow_prompt())
@@ -180,7 +213,9 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "workflow load accepts prompt-only files without front matter" do
-    workflow_path = Path.join(Path.dirname(Workflow.workflow_file_path()), "PROMPT_ONLY_WORKFLOW.md")
+    workflow_path =
+      Path.join(Path.dirname(Workflow.workflow_file_path()), "PROMPT_ONLY_WORKFLOW.md")
+
     File.write!(workflow_path, "Prompt only\n")
 
     assert {:ok, %{config: %{}, prompt: "Prompt only", prompt_template: "Prompt only"}} =
@@ -188,15 +223,20 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "workflow load accepts unterminated front matter with an empty prompt" do
-    workflow_path = Path.join(Path.dirname(Workflow.workflow_file_path()), "UNTERMINATED_WORKFLOW.md")
+    workflow_path =
+      Path.join(Path.dirname(Workflow.workflow_file_path()), "UNTERMINATED_WORKFLOW.md")
+
     File.write!(workflow_path, "---\ntracker:\n  kind: linear\n")
 
-    assert {:ok, %{config: %{"tracker" => %{"kind" => "linear"}}, prompt: "", prompt_template: ""}} =
+    assert {:ok,
+            %{config: %{"tracker" => %{"kind" => "linear"}}, prompt: "", prompt_template: ""}} =
              Workflow.load(workflow_path)
   end
 
   test "workflow load rejects non-map front matter" do
-    workflow_path = Path.join(Path.dirname(Workflow.workflow_file_path()), "INVALID_FRONT_MATTER_WORKFLOW.md")
+    workflow_path =
+      Path.join(Path.dirname(Workflow.workflow_file_path()), "INVALID_FRONT_MATTER_WORKFLOW.md")
+
     File.write!(workflow_path, "---\n- not-a-map\n---\nPrompt body\n")
 
     assert {:error, :workflow_front_matter_not_a_map} = Workflow.load(workflow_path)
@@ -217,7 +257,8 @@ defmodule SymphonyElixir.CoreTest do
     end)
 
     if is_pid(orchestrator_pid) do
-      assert :ok = Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.Orchestrator)
+      assert :ok =
+               Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.Orchestrator)
     end
 
     assert {:ok, pid} = SymphonyElixir.start_link()
@@ -290,6 +331,117 @@ defmodule SymphonyElixir.CoreTest do
       assert File.exists?(workspace)
     after
       File.rm_rf(test_root)
+    end
+  end
+
+  test "continuation issue states keep an existing running agent alive without becoming pickup states" do
+    issue_id = "issue-continuation"
+    issue_identifier = "MT-565"
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_active_states: ["Todo", "Approved"],
+      tracker_continuation_states: ["Todo", "Approved", "In Progress", "In Review"],
+      tracker_terminal_states: ["Done", "Cancelled"]
+    )
+
+    agent_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    state = %Orchestrator.State{
+      running: %{
+        issue_id => %{
+          pid: agent_pid,
+          ref: nil,
+          identifier: issue_identifier,
+          issue: %Issue{id: issue_id, state: "Todo", identifier: issue_identifier},
+          started_at: DateTime.utc_now()
+        }
+      },
+      claimed: MapSet.new([issue_id]),
+      codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      retry_attempts: %{}
+    }
+
+    issue = %Issue{
+      id: issue_id,
+      identifier: issue_identifier,
+      state: "In Progress",
+      title: "Work underway",
+      description: "Already claimed",
+      labels: []
+    }
+
+    updated_state = Orchestrator.reconcile_issue_states_for_test([issue], state)
+
+    assert Map.has_key?(updated_state.running, issue_id)
+    assert MapSet.member?(updated_state.claimed, issue_id)
+    assert Process.alive?(agent_pid)
+    assert updated_state.running[issue_id].issue.state == "In Progress"
+    refute Orchestrator.should_dispatch_issue_for_test(issue, %Orchestrator.State{})
+
+    Process.exit(agent_pid, :normal)
+  end
+
+  test "production reconcile keeps running agents alive in continuation states" do
+    previous_memory_issues = Application.get_env(:symphony_elixir, :memory_tracker_issues)
+    issue_id = "issue-production-continuation"
+    issue_identifier = "MT-566"
+
+    try do
+      write_workflow_file!(Workflow.workflow_file_path(),
+        tracker_kind: "memory",
+        tracker_active_states: ["Todo", "Approved"],
+        tracker_continuation_states: ["Todo", "Approved", "In Progress", "In Review"],
+        tracker_terminal_states: ["Done", "Cancelled"]
+      )
+
+      Application.put_env(:symphony_elixir, :memory_tracker_issues, [
+        %Issue{
+          id: issue_id,
+          identifier: issue_identifier,
+          state: "In Progress",
+          title: "Work underway",
+          description: "Already claimed",
+          labels: []
+        }
+      ])
+
+      agent_pid =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      state = %Orchestrator.State{
+        running: %{
+          issue_id => %{
+            pid: agent_pid,
+            ref: nil,
+            identifier: issue_identifier,
+            issue: %Issue{id: issue_id, state: "Todo", identifier: issue_identifier},
+            started_at: DateTime.utc_now()
+          }
+        },
+        claimed: MapSet.new([issue_id]),
+        codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+        retry_attempts: %{}
+      }
+
+      updated_state = Orchestrator.reconcile_running_issues_for_test(state)
+
+      assert Map.has_key?(updated_state.running, issue_id)
+      assert MapSet.member?(updated_state.claimed, issue_id)
+      assert Process.alive?(agent_pid)
+      assert updated_state.running[issue_id].issue.state == "In Progress"
+
+      Process.exit(agent_pid, :normal)
+    after
+      restore_app_env(:memory_tracker_issues, previous_memory_issues)
     end
   end
 
@@ -683,7 +835,8 @@ defmodule SymphonyElixir.CoreTest do
           tool_name: "linear_graphql",
           result: %{
             "success" => false,
-            "output" => ~s({"error":{"message":"Unsupported dynamic tool: \\"linear_create_issue\\"."}})
+            "output" =>
+              ~s({"error":{"message":"Unsupported dynamic tool: \\"linear_create_issue\\"."}})
           }
         }
       })
@@ -928,7 +1081,9 @@ defmodule SymphonyElixir.CoreTest do
              Orchestrator.handle_call(:request_refresh, {self(), make_ref()}, refreshed_state)
 
     assert coalesced_state.tick_token == refreshed_state.tick_token
-    assert {:noreply, ^coalesced_state} = Orchestrator.handle_info({:tick, stale_tick_token}, coalesced_state)
+
+    assert {:noreply, ^coalesced_state} =
+             Orchestrator.handle_info({:tick, stale_tick_token}, coalesced_state)
   end
 
   test "select_worker_host_for_test skips full ssh hosts under the shared per-host cap" do
@@ -1015,7 +1170,8 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "prompt builder renders issue datetime fields without crashing" do
-    workflow_prompt = "Ticket {{ issue.identifier }} created={{ issue.created_at }} updated={{ issue.updated_at }}"
+    workflow_prompt =
+      "Ticket {{ issue.identifier }} created={{ issue.created_at }} updated={{ issue.updated_at }}"
 
     write_workflow_file!(Workflow.workflow_file_path(), prompt: workflow_prompt)
 
@@ -1152,9 +1308,12 @@ defmodule SymphonyElixir.CoreTest do
       end
     end)
 
-    assert :ok = Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.WorkflowStore)
+    assert :ok =
+             Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.WorkflowStore)
 
-    Workflow.set_workflow_file_path(Path.join(System.tmp_dir!(), "missing-workflow-#{System.unique_integer([:positive])}.md"))
+    Workflow.set_workflow_file_path(
+      Path.join(System.tmp_dir!(), "missing-workflow-#{System.unique_integer([:positive])}.md")
+    )
 
     issue = %Issue{
       identifier: "MT-780",


### PR DESCRIPTION
## Summary

Closes #9.

This separates dispatch states from continuation states so Symphony can pick up only ready issues while keeping already-running issues alive as they move through `In Progress` or `In Review`.

## Implementation

- Adds `tracker.continuation_states` to the config schema.
- Adds `Config.tracker_continuation_states/0`, falling back to dispatch states for backwards compatibility.
- Keeps `Config.tracker_dispatch_states/0` responsible for pickup selection.
- Updates running-issue reconciliation to use continuation states.
- Documents the new config in the README, workflow spec, and generated spec.
- Adds tests proving continuation-only states keep active agents alive without becoming pickup states.

## Why config alone was insufficient

Raw Symphony had a single `active_states` list. That list could not simultaneously mean “eligible for new dispatch” and “safe for an already-running worker to remain active” for workflows that include `In Progress` and `In Review` lanes.

## Tests

```text
mix test test/symphony_elixir/core_test.exs test/symphony_elixir/workspace_and_config_test.exs
92 tests, 0 failures
```
