### PR TITLE
Create follow-up issues for capability gaps

### DIFF
--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -166,7 +166,7 @@ defmodule SymphonyElixir.AgentRunner do
   defp active_issue_state?(state_name) when is_binary(state_name) do
     normalized_state = normalize_issue_state(state_name)
 
-    Config.tracker_dispatch_states()
+    Config.tracker_continuation_states()
     |> Enum.any?(fn active_state -> normalize_issue_state(active_state) == normalized_state end)
   end
 

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -77,7 +77,11 @@ defmodule SymphonyElixir.Config do
   @spec tracker_continuation_states() :: [String.t()]
   def tracker_continuation_states do
     tracker = settings!().tracker
-    tracker.continuation_states || tracker_dispatch_states()
+
+    case tracker.continuation_states do
+      states when is_list(states) and states != [] -> states
+      _ -> tracker_dispatch_states()
+    end
   end
 
   @spec codex_turn_sandbox_policy(Path.t() | nil) :: map()

--- a/elixir/lib/symphony_elixir/linear/adapter.ex
+++ b/elixir/lib/symphony_elixir/linear/adapter.ex
@@ -23,6 +23,37 @@ defmodule SymphonyElixir.Linear.Adapter do
   }
   """
 
+  @create_issue_mutation """
+  mutation SymphonyCreateIssue($input: IssueCreateInput!) {
+    issueCreate(input: $input) {
+      success
+      issue {
+        id
+        identifier
+        url
+      }
+    }
+  }
+  """
+
+  @issue_context_query """
+  query SymphonyIssueContext($issueId: String!, $stateName: String!) {
+    issue(id: $issueId) {
+      team {
+        id
+        states(filter: {name: {eq: $stateName}}, first: 1) {
+          nodes {
+            id
+          }
+        }
+      }
+      project {
+        id
+      }
+    }
+  }
+  """
+
   @state_lookup_query """
   query SymphonyResolveStateId($issueId: String!, $stateName: String!) {
     issue(id: $issueId) {
@@ -58,6 +89,24 @@ defmodule SymphonyElixir.Linear.Adapter do
     end
   end
 
+  @spec create_issue(map()) :: {:ok, map()} | {:error, term()}
+  def create_issue(%{source_issue_id: source_issue_id, title: title, description: description} = attrs)
+      when is_binary(source_issue_id) and is_binary(title) and is_binary(description) do
+    state_name = Map.get(attrs, :state_name, "Backlog")
+
+    with {:ok, context} <- resolve_issue_context(source_issue_id, state_name),
+         {:ok, response} <-
+           client_module().graphql(@create_issue_mutation, %{input: issue_create_input(context, title, description)}),
+         true <- get_in(response, ["data", "issueCreate", "success"]) == true,
+         %{} = issue <- get_in(response, ["data", "issueCreate", "issue"]) do
+      {:ok, issue}
+    else
+      false -> {:error, :issue_create_failed}
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :issue_create_failed}
+    end
+  end
+
   @spec update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
   def update_issue_state(issue_id, state_name)
       when is_binary(issue_id) and is_binary(state_name) do
@@ -87,5 +136,34 @@ defmodule SymphonyElixir.Linear.Adapter do
       {:error, reason} -> {:error, reason}
       _ -> {:error, :state_not_found}
     end
+  end
+
+  defp resolve_issue_context(issue_id, state_name) do
+    with {:ok, response} <-
+           client_module().graphql(@issue_context_query, %{issueId: issue_id, stateName: state_name}),
+         %{} = issue <- get_in(response, ["data", "issue"]),
+         team_id when is_binary(team_id) <- get_in(issue, ["team", "id"]) do
+      {:ok,
+       %{
+         team_id: team_id,
+         project_id: get_in(issue, ["project", "id"]),
+         state_id: get_in(issue, ["team", "states", "nodes", Access.at(0), "id"])
+       }}
+    else
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :issue_context_not_found}
+    end
+  end
+
+  defp issue_create_input(context, title, description) do
+    %{
+      teamId: context.team_id,
+      projectId: context.project_id,
+      stateId: context.state_id,
+      title: title,
+      description: description
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
   end
 end

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -137,15 +137,11 @@ defmodule SymphonyElixir.Orchestrator do
           case reason do
             :normal ->
               if credit_exhausted_running_entry?(running_entry) do
-                Logger.warning(
-                  "Agent task paused for issue_id=#{issue_id} session_id=#{session_id}; Codex credits are exhausted"
-                )
+                Logger.warning("Agent task paused for issue_id=#{issue_id} session_id=#{session_id}; Codex credits are exhausted")
 
                 schedule_credit_exhausted_retry(state, issue_id, running_entry)
               else
-                Logger.info(
-                  "Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling active-state continuation check"
-                )
+                Logger.info("Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling active-state continuation check")
 
                 state
                 |> complete_issue(issue_id)
@@ -160,15 +156,11 @@ defmodule SymphonyElixir.Orchestrator do
             _ ->
               if credit_exhausted_running_entry?(running_entry) or
                    credit_exhausted_reason?(reason) do
-                Logger.warning(
-                  "Agent task paused for issue_id=#{issue_id} session_id=#{session_id}; Codex credits appear exhausted reason=#{inspect(reason)}"
-                )
+                Logger.warning("Agent task paused for issue_id=#{issue_id} session_id=#{session_id}; Codex credits appear exhausted reason=#{inspect(reason)}")
 
                 schedule_credit_exhausted_retry(state, issue_id, running_entry)
               else
-                Logger.warning(
-                  "Agent task exited for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}; scheduling retry"
-                )
+                Logger.warning("Agent task exited for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}; scheduling retry")
 
                 next_attempt = next_retry_attempt_from_running(running_entry)
 
@@ -181,9 +173,7 @@ defmodule SymphonyElixir.Orchestrator do
               end
           end
 
-        Logger.info(
-          "Agent task finished for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}"
-        )
+        Logger.info("Agent task finished for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}")
 
         notify_dashboard()
         {:noreply, state}
@@ -333,9 +323,7 @@ defmodule SymphonyElixir.Orchestrator do
           |> reconcile_missing_running_issue_ids(running_ids, issues)
 
         {:error, reason} ->
-          Logger.debug(
-            "Failed to refresh running issue states: #{inspect(reason)}; keeping active workers"
-          )
+          Logger.debug("Failed to refresh running issue states: #{inspect(reason)}; keeping active workers")
 
           state
       end
@@ -397,16 +385,12 @@ defmodule SymphonyElixir.Orchestrator do
   defp reconcile_issue_state(%Issue{} = issue, state, active_states, terminal_states) do
     cond do
       terminal_issue_state?(issue.state, terminal_states) ->
-        Logger.info(
-          "Issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; stopping active agent"
-        )
+        Logger.info("Issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; stopping active agent")
 
         terminate_running_issue(state, issue.id, true)
 
       !issue_routable_to_worker?(issue) ->
-        Logger.info(
-          "Issue no longer routed to this worker: #{issue_context(issue)} assignee=#{inspect(issue.assignee_id)}; stopping active agent"
-        )
+        Logger.info("Issue no longer routed to this worker: #{issue_context(issue)} assignee=#{inspect(issue.assignee_id)}; stopping active agent")
 
         terminate_running_issue(state, issue.id, false)
 
@@ -414,9 +398,7 @@ defmodule SymphonyElixir.Orchestrator do
         refresh_running_issue_state(state, issue)
 
       true ->
-        Logger.info(
-          "Issue moved to non-active state: #{issue_context(issue)} state=#{issue.state}; stopping active agent"
-        )
+        Logger.info("Issue moved to non-active state: #{issue_context(issue)} state=#{issue.state}; stopping active agent")
 
         terminate_running_issue(state, issue.id, false)
     end
@@ -449,14 +431,10 @@ defmodule SymphonyElixir.Orchestrator do
   defp log_missing_running_issue(%State{} = state, issue_id) when is_binary(issue_id) do
     case Map.get(state.running, issue_id) do
       %{identifier: identifier} ->
-        Logger.info(
-          "Issue no longer visible during running-state refresh: issue_id=#{issue_id} issue_identifier=#{identifier}; stopping active agent"
-        )
+        Logger.info("Issue no longer visible during running-state refresh: issue_id=#{issue_id} issue_identifier=#{identifier}; stopping active agent")
 
       _ ->
-        Logger.info(
-          "Issue no longer visible during running-state refresh: issue_id=#{issue_id}; stopping active agent"
-        )
+        Logger.info("Issue no longer visible during running-state refresh: issue_id=#{issue_id}; stopping active agent")
     end
   end
 
@@ -514,24 +492,43 @@ defmodule SymphonyElixir.Orchestrator do
         :ok
 
       {:error, reason} ->
-        Logger.warning(
-          "Failed to comment capability gap for issue_id=#{issue_id} issue_identifier=#{identifier}: #{inspect(reason)}"
-        )
+        Logger.warning("Failed to comment capability gap for issue_id=#{issue_id} issue_identifier=#{identifier}: #{inspect(reason)}")
     end
 
     case Tracker.update_issue_state(issue_id, @blocked_state_name) do
       :ok ->
-        Logger.warning(
-          "Blocked issue after agent capability gap: issue_id=#{issue_id} issue_identifier=#{identifier} missing=#{kind}"
-        )
+        Logger.warning("Blocked issue after agent capability gap: issue_id=#{issue_id} issue_identifier=#{identifier} missing=#{kind}")
 
       {:error, reason} ->
-        Logger.warning(
-          "Failed to move capability gap issue to #{@blocked_state_name}: issue_id=#{issue_id} issue_identifier=#{identifier} reason=#{inspect(reason)}"
-        )
+        Logger.warning("Failed to move capability gap issue to #{@blocked_state_name}: issue_id=#{issue_id} issue_identifier=#{identifier} reason=#{inspect(reason)}")
     end
 
+    create_capability_gap_fix_issue(issue_id, identifier, kind, details)
+
     terminate_running_issue(state, issue_id, false)
+  end
+
+  defp create_capability_gap_fix_issue(issue_id, identifier, kind, details) do
+    attrs = %{
+      source_issue_id: issue_id,
+      state_name: "Backlog",
+      title: "Fix Symphony capability gap for #{identifier}",
+      description: capability_gap_fix_issue_description(identifier, kind, details)
+    }
+
+    case Tracker.create_issue(attrs) do
+      {:ok, %{"identifier" => created_identifier, "url" => url}} ->
+        Logger.warning("Created capability gap fix issue #{created_identifier} for issue_id=#{issue_id} issue_identifier=#{identifier} url=#{url}")
+
+      {:ok, %{identifier: created_identifier, url: url}} ->
+        Logger.warning("Created capability gap fix issue #{created_identifier} for issue_id=#{issue_id} issue_identifier=#{identifier} url=#{url}")
+
+      {:ok, created_issue} ->
+        Logger.warning("Created capability gap fix issue for issue_id=#{issue_id} issue_identifier=#{identifier}: #{inspect(created_issue)}")
+
+      {:error, reason} ->
+        Logger.error("Failed to create capability gap fix issue for issue_id=#{issue_id} issue_identifier=#{identifier}: #{inspect(reason)}")
+    end
   end
 
   defp capability_gap_comment(kind, details) do
@@ -542,6 +539,22 @@ defmodule SymphonyElixir.Orchestrator do
     Details: #{details}
 
     The run was stopped to avoid token-consuming workarounds. Fix the missing tool, skill, or permission, then move the issue back to an active pickup state.
+    """
+  end
+
+  defp capability_gap_fix_issue_description(identifier, kind, details) do
+    """
+    Symphony stopped #{identifier} because a required agent capability was missing.
+
+    Missing capability: #{kind}
+
+    Details:
+
+    ```text
+    #{details}
+    ```
+
+    Fix the missing tool, skill, credential, or permission. After the fix is available to Symphony, move #{identifier} back to an active pickup state.
     """
   end
 
@@ -571,9 +584,7 @@ defmodule SymphonyElixir.Orchestrator do
       identifier = Map.get(running_entry, :identifier, issue_id)
       session_id = running_entry_session_id(running_entry)
 
-      Logger.warning(
-        "Issue stalled: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; restarting with backoff"
-      )
+      Logger.warning("Issue stalled: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; restarting with backoff")
 
       next_attempt = next_retry_attempt_from_running(running_entry)
 
@@ -636,8 +647,7 @@ defmodule SymphonyElixir.Orchestrator do
   defp sort_issues_for_dispatch(issues) when is_list(issues) do
     Enum.sort_by(issues, fn
       %Issue{} = issue ->
-        {priority_rank(issue.priority), issue_created_at_sort_key(issue),
-         issue.identifier || issue.id || ""}
+        {priority_rank(issue.priority), issue_created_at_sort_key(issue), issue.identifier || issue.id || ""}
 
       _ ->
         {priority_rank(nil), issue_created_at_sort_key(nil), ""}
@@ -777,23 +787,17 @@ defmodule SymphonyElixir.Orchestrator do
         do_dispatch_issue(state, refreshed_issue, attempt, preferred_worker_host)
 
       {:skip, :missing} ->
-        Logger.info(
-          "Skipping dispatch; issue no longer active or visible: #{issue_context(issue)}"
-        )
+        Logger.info("Skipping dispatch; issue no longer active or visible: #{issue_context(issue)}")
 
         state
 
       {:skip, %Issue{} = refreshed_issue} ->
-        Logger.info(
-          "Skipping stale dispatch after issue refresh: #{issue_context(refreshed_issue)} state=#{inspect(refreshed_issue.state)} blocked_by=#{length(refreshed_issue.blocked_by)}"
-        )
+        Logger.info("Skipping stale dispatch after issue refresh: #{issue_context(refreshed_issue)} state=#{inspect(refreshed_issue.state)} blocked_by=#{length(refreshed_issue.blocked_by)}")
 
         state
 
       {:error, reason} ->
-        Logger.warning(
-          "Skipping dispatch; issue refresh failed for #{issue_context(issue)}: #{inspect(reason)}"
-        )
+        Logger.warning("Skipping dispatch; issue refresh failed for #{issue_context(issue)}: #{inspect(reason)}")
 
         state
     end
@@ -804,9 +808,7 @@ defmodule SymphonyElixir.Orchestrator do
 
     case select_worker_host(state, preferred_worker_host) do
       :no_worker_capacity ->
-        Logger.debug(
-          "No SSH worker slots available for #{issue_context(issue)} preferred_worker_host=#{inspect(preferred_worker_host)}"
-        )
+        Logger.debug("No SSH worker slots available for #{issue_context(issue)} preferred_worker_host=#{inspect(preferred_worker_host)}")
 
         state
 
@@ -822,9 +824,7 @@ defmodule SymphonyElixir.Orchestrator do
       {:ok, pid} ->
         ref = Process.monitor(pid)
 
-        Logger.info(
-          "Dispatching issue to agent: #{issue_context(issue)} pid=#{inspect(pid)} attempt=#{inspect(attempt)} worker_host=#{worker_host || "local"}"
-        )
+        Logger.info("Dispatching issue to agent: #{issue_context(issue)} pid=#{inspect(pid)} attempt=#{inspect(attempt)} worker_host=#{worker_host || "local"}")
 
         running =
           Map.put(state.running, issue.id, %{
@@ -934,9 +934,7 @@ defmodule SymphonyElixir.Orchestrator do
 
     error_suffix = if is_binary(error), do: " error=#{error}", else: ""
 
-    Logger.warning(
-      "Retrying issue_id=#{issue_id} issue_identifier=#{identifier} in #{delay_ms}ms (attempt #{next_attempt})#{error_suffix}"
-    )
+    Logger.warning("Retrying issue_id=#{issue_id} issue_identifier=#{identifier} in #{delay_ms}ms (attempt #{next_attempt})#{error_suffix}")
 
     %{
       state
@@ -971,8 +969,7 @@ defmodule SymphonyElixir.Orchestrator do
           workspace_path: Map.get(retry_entry, :workspace_path)
         }
 
-        {:ok, attempt, metadata,
-         %{state | retry_attempts: Map.delete(state.retry_attempts, issue_id)}}
+        {:ok, attempt, metadata, %{state | retry_attempts: Map.delete(state.retry_attempts, issue_id)}}
 
       _ ->
         :missing
@@ -987,9 +984,7 @@ defmodule SymphonyElixir.Orchestrator do
         |> handle_retry_issue_lookup(state, issue_id, attempt, metadata)
 
       {:error, reason} ->
-        Logger.warning(
-          "Retry poll failed for issue_id=#{issue_id} issue_identifier=#{metadata[:identifier] || issue_id}: #{inspect(reason)}"
-        )
+        Logger.warning("Retry poll failed for issue_id=#{issue_id} issue_identifier=#{metadata[:identifier] || issue_id}: #{inspect(reason)}")
 
         {:noreply,
          schedule_issue_retry(
@@ -1006,9 +1001,7 @@ defmodule SymphonyElixir.Orchestrator do
 
     cond do
       terminal_issue_state?(issue.state, terminal_states) ->
-        Logger.info(
-          "Issue state is terminal: issue_id=#{issue_id} issue_identifier=#{issue.identifier} state=#{issue.state}; removing associated workspace"
-        )
+        Logger.info("Issue state is terminal: issue_id=#{issue_id} issue_identifier=#{issue.identifier} state=#{issue.state}; removing associated workspace")
 
         cleanup_issue_workspace(issue.identifier, metadata[:worker_host])
         {:noreply, release_issue_claim(state, issue_id)}
@@ -1021,9 +1014,7 @@ defmodule SymphonyElixir.Orchestrator do
         handle_active_retry(state, issue, attempt, metadata)
 
       true ->
-        Logger.debug(
-          "Issue left active states, removing claim issue_id=#{issue_id} issue_identifier=#{issue.identifier}"
-        )
+        Logger.debug("Issue left active states, removing claim issue_id=#{issue_id} issue_identifier=#{issue.identifier}")
 
         {:noreply, release_issue_claim(state, issue_id)}
     end
@@ -1055,9 +1046,7 @@ defmodule SymphonyElixir.Orchestrator do
         end)
 
       {:error, reason} ->
-        Logger.warning(
-          "Skipping startup terminal workspace cleanup; failed to fetch terminal issues: #{inspect(reason)}"
-        )
+        Logger.warning("Skipping startup terminal workspace cleanup; failed to fetch terminal issues: #{inspect(reason)}")
     end
   end
 
@@ -1089,15 +1078,11 @@ defmodule SymphonyElixir.Orchestrator do
   defp handle_credit_pause_retry(state, issue, attempt, metadata) do
     if dispatch_slots_available?(issue, state) and
          worker_slots_available?(state, metadata[:worker_host]) do
-      Logger.info(
-        "Retrying issue after Codex credit pause: #{issue_context(issue)} state=#{issue.state}"
-      )
+      Logger.info("Retrying issue after Codex credit pause: #{issue_context(issue)} state=#{issue.state}")
 
       {:noreply, do_dispatch_issue(state, issue, attempt, metadata[:worker_host])}
     else
-      Logger.debug(
-        "No available slots for retrying credit-paused #{issue_context(issue)}; retrying again"
-      )
+      Logger.debug("No available slots for retrying credit-paused #{issue_context(issue)}; retrying again")
 
       {:noreply,
        schedule_issue_retry(
@@ -1482,8 +1467,7 @@ defmodule SymphonyElixir.Orchestrator do
         end
 
       _ ->
-        {Map.get(running_entry, :credit_exhausted, false),
-         Map.get(running_entry, :credit_retry_delay_ms)}
+        {Map.get(running_entry, :credit_exhausted, false), Map.get(running_entry, :credit_retry_delay_ms)}
     end
   end
 
@@ -1589,8 +1573,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp capability_gap_from_update(%{event: :turn_input_required} = update) do
-    {:permission,
-     "Codex required interactive input during an unattended run: #{update_text(update)}"}
+    {:permission, "Codex required interactive input during an unattended run: #{update_text(update)}"}
   end
 
   defp capability_gap_from_update(%{event: :unsupported_tool_call} = update) do
@@ -1602,8 +1585,7 @@ defmodule SymphonyElixir.Orchestrator do
     if capability_gap_text?(update_text(update)) do
       tool_name = update[:tool_name] || "<unknown>"
 
-      {:tool,
-       "Tool call failed because a capability appears unavailable: #{tool_name}. #{update_text(update)}"}
+      {:tool, "Tool call failed because a capability appears unavailable: #{tool_name}. #{update_text(update)}"}
     end
   end
 

--- a/elixir/lib/symphony_elixir/tracker.ex
+++ b/elixir/lib/symphony_elixir/tracker.ex
@@ -9,6 +9,7 @@ defmodule SymphonyElixir.Tracker do
   @callback fetch_issues_by_states([String.t()]) :: {:ok, [term()]} | {:error, term()}
   @callback fetch_issue_states_by_ids([String.t()]) :: {:ok, [term()]} | {:error, term()}
   @callback create_comment(String.t(), String.t()) :: :ok | {:error, term()}
+  @callback create_issue(map()) :: {:ok, map()} | {:error, term()}
   @callback update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
 
   @spec fetch_candidate_issues() :: {:ok, [term()]} | {:error, term()}
@@ -29,6 +30,11 @@ defmodule SymphonyElixir.Tracker do
   @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
   def create_comment(issue_id, body) do
     adapter().create_comment(issue_id, body)
+  end
+
+  @spec create_issue(map()) :: {:ok, map()} | {:error, term()}
+  def create_issue(attrs) when is_map(attrs) do
+    adapter().create_issue(attrs)
   end
 
   @spec update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}

--- a/elixir/lib/symphony_elixir/tracker/memory.ex
+++ b/elixir/lib/symphony_elixir/tracker/memory.ex
@@ -41,6 +41,19 @@ defmodule SymphonyElixir.Tracker.Memory do
     :ok
   end
 
+  @spec create_issue(map()) :: {:ok, map()} | {:error, term()}
+  def create_issue(attrs) when is_map(attrs) do
+    issue = %{
+      id: Map.get(attrs, :id, "created-#{System.unique_integer([:positive])}"),
+      identifier: Map.get(attrs, :identifier, "MEM-#{System.unique_integer([:positive])}"),
+      title: Map.get(attrs, :title),
+      url: Map.get(attrs, :url)
+    }
+
+    send_event({:memory_tracker_issue_create, attrs, issue})
+    {:ok, issue}
+  end
+
   @spec update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
   def update_issue_state(issue_id, state_name) do
     send_event({:memory_tracker_state_update, issue_id, state_name})

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -228,8 +228,7 @@ defmodule SymphonyElixir.CoreTest do
 
     File.write!(workflow_path, "---\ntracker:\n  kind: linear\n")
 
-    assert {:ok,
-            %{config: %{"tracker" => %{"kind" => "linear"}}, prompt: "", prompt_template: ""}} =
+    assert {:ok, %{config: %{"tracker" => %{"kind" => "linear"}}, prompt: "", prompt_template: ""}} =
              Workflow.load(workflow_path)
   end
 
@@ -835,8 +834,7 @@ defmodule SymphonyElixir.CoreTest do
           tool_name: "linear_graphql",
           result: %{
             "success" => false,
-            "output" =>
-              ~s({"error":{"message":"Unsupported dynamic tool: \\"linear_create_issue\\"."}})
+            "output" => ~s({"error":{"message":"Unsupported dynamic tool: \\"linear_create_issue\\"."}})
           }
         }
       })
@@ -846,6 +844,13 @@ defmodule SymphonyElixir.CoreTest do
       assert body =~ "Missing capability: tool"
       assert body =~ "Unsupported dynamic tool"
       assert_receive {:memory_tracker_state_update, ^issue_id, "Blocked"}, 500
+      assert_receive {:memory_tracker_issue_create, attrs, created_issue}, 500
+      assert attrs.source_issue_id == issue_id
+      assert attrs.state_name == "Backlog"
+      assert attrs.title == "Fix Symphony capability gap for MT-564"
+      assert attrs.description =~ "Symphony stopped MT-564"
+      assert attrs.description =~ "Unsupported dynamic tool"
+      assert is_binary(created_issue.identifier)
 
       Process.sleep(50)
       state = :sys.get_state(pid)
@@ -1311,9 +1316,7 @@ defmodule SymphonyElixir.CoreTest do
     assert :ok =
              Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.WorkflowStore)
 
-    Workflow.set_workflow_file_path(
-      Path.join(System.tmp_dir!(), "missing-workflow-#{System.unique_integer([:positive])}.md")
-    )
+    Workflow.set_workflow_file_path(Path.join(System.tmp_dir!(), "missing-workflow-#{System.unique_integer([:positive])}.md"))
 
     issue = %Issue{
       identifier: "MT-780",

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -193,8 +193,10 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_issues_by_states([" in progress ", 42])
     assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_issue_states_by_ids(["issue-1"])
     assert :ok = SymphonyElixir.Tracker.create_comment("issue-1", "comment")
+    assert {:ok, created_issue} = SymphonyElixir.Tracker.create_issue(%{title: "Fix blocker"})
     assert :ok = SymphonyElixir.Tracker.update_issue_state("issue-1", "Done")
     assert_receive {:memory_tracker_comment, "issue-1", "comment"}
+    assert_receive {:memory_tracker_issue_create, %{title: "Fix blocker"}, ^created_issue}
     assert_receive {:memory_tracker_state_update, "issue-1", "Done"}
 
     Application.delete_env(:symphony_elixir, :memory_tracker_recipient)
@@ -243,6 +245,51 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     Process.put({FakeLinearClient, :graphql_result}, :unexpected)
     assert {:error, :comment_create_failed} = Adapter.create_comment("issue-1", "odd")
+
+    Process.put(
+      {FakeLinearClient, :graphql_results},
+      [
+        {:ok,
+         %{
+           "data" => %{
+             "issue" => %{
+               "team" => %{
+                 "id" => "team-1",
+                 "states" => %{"nodes" => [%{"id" => "state-backlog"}]}
+               },
+               "project" => %{"id" => "project-1"}
+             }
+           }
+         }},
+        {:ok,
+         %{
+           "data" => %{
+             "issueCreate" => %{
+               "success" => true,
+               "issue" => %{"id" => "created-1", "identifier" => "MT-999", "url" => "https://linear.test/MT-999"}
+             }
+           }
+         }}
+      ]
+    )
+
+    assert {:ok, %{"identifier" => "MT-999"}} =
+             Adapter.create_issue(%{
+               source_issue_id: "issue-1",
+               title: "Fix missing tool",
+               description: "Install the tool"
+             })
+
+    assert_receive {:graphql_called, issue_context_query, %{issueId: "issue-1", stateName: "Backlog"}}
+    assert issue_context_query =~ "SymphonyIssueContext"
+
+    assert_receive {:graphql_called, create_issue_query, %{input: input}}
+    assert create_issue_query =~ "issueCreate"
+    assert input.teamId == "team-1"
+    assert input.projectId == "project-1"
+    assert input.stateId == "state-backlog"
+    assert input.title == "Fix missing tool"
+    assert input.description == "Install the tool"
 
     Process.put(
       {FakeLinearClient, :graphql_results},


### PR DESCRIPTION
## Summary

Closes #11.

This lets Symphony create a tracked follow-up issue whenever a capability gap blocks an active issue. The original issue is still blocked with an explanation, and the missing runner/platform capability becomes its own item of work.

## Implementation

- Adds `create_issue/1` to the tracker behavior and public tracker wrapper.
- Implements Linear `issueCreate` through the GraphQL adapter.
- Adds memory tracker issue creation for tests.
- Extends capability-gap blocking to create a follow-up issue with context.
- Adds regression coverage for follow-up issue creation.

## Why config alone was insufficient

Raw Symphony had no tracker-level issue creation abstraction and no Linear issue creation path. Lifecycle hooks could call external scripts, but they would not be triggered by structured capability-gap detection and would make blocker handling tracker-specific.

## Tests

```text
mix test test/symphony_elixir/core_test.exs test/symphony_elixir/extensions_test.exs
60 tests, 0 failures
```
