### PR TITLE
Move issues to In Progress on dispatch

### DIFF
--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -16,6 +16,7 @@ defmodule SymphonyElixir.Orchestrator do
   @credit_retry_min_delay_ms 60_000
   @credit_retry_safety_margin_ms 5_000
   @blocked_state_name "Blocked"
+  @in_progress_state_name "In Progress"
   # Slightly above the dashboard render interval so "checking now…" can render.
   @poll_transition_render_delay_ms 20
   @empty_codex_totals %{
@@ -813,8 +814,50 @@ defmodule SymphonyElixir.Orchestrator do
         state
 
       worker_host ->
-        spawn_issue_on_worker_host(state, issue, attempt, recipient, worker_host)
+        case mark_issue_in_progress(issue) do
+          {:ok, issue} ->
+            spawn_issue_on_worker_host(state, issue, attempt, recipient, worker_host)
+
+          {:error, reason} ->
+            block_issue_before_dispatch(state, issue, reason)
+        end
     end
+  end
+
+  defp mark_issue_in_progress(%Issue{state: @in_progress_state_name} = issue), do: {:ok, issue}
+
+  defp mark_issue_in_progress(%Issue{id: issue_id} = issue) when is_binary(issue_id) do
+    case Tracker.update_issue_state(issue_id, @in_progress_state_name) do
+      :ok ->
+        {:ok, %{issue | state: @in_progress_state_name}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp mark_issue_in_progress(issue), do: {:ok, issue}
+
+  defp block_issue_before_dispatch(%State{} = state, %Issue{} = issue, reason) do
+    message = """
+    Symphony blocked this issue before dispatch because it could not move the issue to #{@in_progress_state_name}.
+
+    Missing or failing capability: tracker state update
+    Reason: #{inspect(reason)}
+
+    The run was stopped before starting Codex work to avoid token-consuming work outside the expected Linear lifecycle.
+    """
+
+    _ = Tracker.create_comment(issue.id, String.trim(message))
+    _ = Tracker.update_issue_state(issue.id, @blocked_state_name)
+
+    Logger.error("Unable to move issue to #{@in_progress_state_name} before dispatch for #{issue_context(issue)}: #{inspect(reason)}")
+
+    %{
+      state
+      | claimed: MapSet.delete(state.claimed, issue.id),
+        retry_attempts: Map.delete(state.retry_attempts, issue.id)
+    }
   end
 
   defp spawn_issue_on_worker_host(%State{} = state, issue, attempt, recipient, worker_host) do

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -444,6 +444,49 @@ defmodule SymphonyElixir.CoreTest do
     end
   end
 
+  test "dispatch moves pickup issues to in progress before starting work" do
+    previous_memory_issues = Application.get_env(:symphony_elixir, :memory_tracker_issues)
+    previous_memory_recipient = Application.get_env(:symphony_elixir, :memory_tracker_recipient)
+    issue_id = "issue-start-state"
+    orchestrator_name = Module.concat(__MODULE__, :StartStateOrchestrator)
+
+    try do
+      write_workflow_file!(Workflow.workflow_file_path(),
+        tracker_kind: "memory",
+        tracker_active_states: ["Todo", "Approved"],
+        tracker_continuation_states: ["Todo", "Approved", "In Progress", "In Review"],
+        max_concurrent_agents: 1,
+        codex_command: "/bin/false app-server"
+      )
+
+      Application.put_env(:symphony_elixir, :memory_tracker_recipient, self())
+
+      Application.put_env(:symphony_elixir, :memory_tracker_issues, [
+        %Issue{
+          id: issue_id,
+          identifier: "MT-567",
+          state: "Todo",
+          title: "Start work",
+          description: "Move state before Codex starts",
+          labels: []
+        }
+      ])
+
+      {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+      assert_receive {:memory_tracker_state_update, ^issue_id, "In Progress"}, 500
+
+      on_exit(fn ->
+        if Process.alive?(pid) do
+          Process.exit(pid, :normal)
+        end
+      end)
+    after
+      restore_app_env(:memory_tracker_issues, previous_memory_issues)
+      restore_app_env(:memory_tracker_recipient, previous_memory_recipient)
+    end
+  end
+
   test "terminal issue state stops running agent and cleans workspace" do
     test_root =
       Path.join(


### PR DESCRIPTION
## Summary

Closes #13.

This moves tracker issues to `In Progress` before Symphony launches Codex work. If Symphony cannot update the tracker, it blocks the issue before starting the agent so the runner does not spend tokens outside the expected workflow lifecycle.

## Implementation

- Adds an `In Progress` transition before `AgentRunner.run/3` is spawned.
- Skips the update when the issue is already `In Progress`.
- Blocks the issue before dispatch if the tracker state update fails.
- Leaves a blocker comment explaining the missing/failing capability.
- Clears claim/retry bookkeeping for pre-dispatch blocked issues.
- Adds a memory-tracker regression test proving the state update happens before work starts.

## Why config alone was insufficient

Raw Symphony config could define state names, but could not enforce a transition between issue selection and Codex launch. Prompting the agent to move the issue is too late and unreliable; the orchestrator must own the lifecycle transition.

## Tests

```text
mix test test/symphony_elixir/core_test.exs
49 tests, 0 failures
```
